### PR TITLE
Dev

### DIFF
--- a/src/Plotter.py
+++ b/src/Plotter.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Optional
 from pathlib import Path
 import matplotlib.pyplot as plt
 import mplfinance as mpf
@@ -16,7 +16,7 @@ class Plotter:
         self,
         data,
         source_folder,
-        save_folder: Union[Path, None] = None,
+        save_folder: Optional[Path] = None,
     ):
         self.source_folder = source_folder
         self.save_folder = save_folder

--- a/src/Plotter.py
+++ b/src/Plotter.py
@@ -5,6 +5,7 @@ import mplfinance as mpf
 import pandas as pd
 from utils import csv_loader
 from datetime import datetime
+from functools import lru_cache
 
 
 class Plotter:
@@ -166,6 +167,7 @@ class Plotter:
         plt.close("all")
         self.plot()
 
+    @lru_cache(maxsize=6)
     def _prep_dataframe(self, sym: str, end_date: datetime) -> pd.DataFrame:
         return csv_loader(
             self.source_folder / f"{sym.lower()}.csv",

--- a/src/init.py
+++ b/src/init.py
@@ -208,7 +208,7 @@ def process(sym_list: List, fns: Tuple[Callable, ...]) -> List[dict]:
 
 
 if __name__ == "__main__":
-    version = "2.1.3"
+    version = "2.1.4"
 
     # Run the below code only when imported
     DIR = Path(__file__).parent

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,8 +1,12 @@
 from typing import Tuple, Optional, TypeVar
+from datetime import datetime
+from pathlib import Path
 import numpy as np
 import pandas as pd
 import logging
 import sys
+import io
+import os
 
 LineCoordinates = Tuple[Tuple[pd.Timestamp, float], Tuple[pd.Timestamp, float]]
 
@@ -74,6 +78,143 @@ def get_DataFrame(file) -> pd.DataFrame:
     return pd.read_csv(
         file, index_col="Date", parse_dates=["Date"], na_filter=False
     )
+
+
+def csv_loader(
+    file_path: Path,
+    period=160,
+    end_date: Optional[datetime] = None,
+    chunk_size=1024 * 6,
+) -> pd.DataFrame:
+
+    def get_date(start, chunk) -> datetime:
+        end = chunk.find(b",", start)
+
+        date_str = chunk[start:end].decode()
+
+        if len(date_str) > 10:
+            return datetime.strptime(date_str[:16], datetime_fmt)
+
+        return datetime.strptime(date_str, date_fmt)
+
+    size = os.path.getsize(file_path)
+    datetime_fmt = "%Y-%m-%d %H:%M"
+    date_fmt = "%Y-%m-%d"
+
+    if size <= chunk_size and not end_date:
+        return pd.read_csv(
+            file_path, index_col="Date", parse_dates=["Date"]
+        ).iloc[-period:]
+
+    chunks_read = []  # store the bytes chunk in a list
+    start_date = None
+    prev_chunk_start_line = None
+    holiday_offset = max(3, period // 50 * 3)
+
+    if end_date:
+        start_date = end_date - pd.offsets.BDay(period + holiday_offset)
+
+    # Open in binary mode and read from end of file
+    with file_path.open("rb") as f:
+
+        # Read the first line of file to get column names
+        columns = f.readline()
+
+        curr_pos = size
+
+        while curr_pos > 0:
+            read_size = min(chunk_size, curr_pos)
+
+            # Set the current read position in the file
+            f.seek(curr_pos - read_size)
+
+            # From the current position read n bytes
+            chunk = f.read(read_size)
+
+            if end_date:
+                # First line in a chunk may not be complete line
+                # So skip the first line and parse the first date in chunk
+                newline_index = chunk.find(b"\n")
+
+                start = newline_index + 1
+
+                try:
+                    current_dt = get_date(start, chunk)
+                except ValueError:
+                    break
+
+                # start storing chunks once end date has reached
+                if current_dt <= end_date:
+                    if prev_chunk_start_line:
+                        chunk = chunk + prev_chunk_start_line
+                        prev_chunk_start_line = None
+
+                    if start_date and current_dt <= start_date:
+                        # reached starting date
+                        # add the columns to chunk and append it
+                        chunks_read.append(columns + chunk[start:])
+                        break
+
+                    chunks_read.append(chunk)
+                else:
+                    prev_chunk_start_line = chunk[: chunk.find(b"\n")]
+
+            else:
+
+                if curr_pos == size:
+                    # On first chunk, get the last date to calculate start_date
+                    last_newline_index = chunk[:-1].rfind(b"\n")
+
+                    start = last_newline_index + 1
+                    last_dt = get_date(start, chunk)
+
+                    start_date = last_dt - pd.offsets.BDay(
+                        period + holiday_offset
+                    )
+
+                # First line may not be a complete line.
+                # To skip this line, find the first newline character
+                newline_index = chunk.find(b"\n")
+
+                start = newline_index + 1
+
+                current_dt = get_date(start, chunk)
+
+                if start_date is None:
+                    start_date = datetime.now() - pd.offsets.BDay(
+                        period + holiday_offset
+                    )
+
+                if current_dt <= start_date:
+                    # Concatenate the columns and chunk together
+                    # and append to list
+                    chunks_read.append(columns + chunk[start:])
+                    break
+
+                # we are storing the chunks in bottom first order.
+                # This has to be corrected later by reversing the list
+                chunks_read.append(chunk)
+
+            curr_pos -= read_size
+
+        if end_date and not chunks_read:
+            # If chunks_read is empty, end_date was not found in file
+            raise IndexError("Date out of bounds of current DataFrame")
+
+        # Reverse the list and join it into a bytes string.
+        # Store the result in a buffer
+        buffer = io.BytesIO(b"".join(chunks_read[::-1]))
+
+    df = pd.read_csv(
+        buffer,
+        parse_dates=["Date"],
+        index_col="Date",
+    )
+
+    if end_date:
+        return df.loc[:end_date].iloc[-period:]
+    else:
+        return df.iloc[-period:]
 
 
 def is_triangle(

--- a/src/utils.py
+++ b/src/utils.py
@@ -61,25 +61,6 @@ def get_atr(
     return tr.tr.rolling(window=window).mean()
 
 
-def has_time_component(datetime_index: pd.DatetimeIndex) -> bool:
-    """Return True if any value in DatetimeIndex has time component
-    other than `00:00:00` (Midnight hour)
-
-    Ex Datetime(2023, 12, 10)           ->  `00:00:00` (Defaults to midnight)
-       Datetime(2023, 12, 10, 0, 0)     ->  `00:00:00` (Midnight time)
-       Datetime(2023, 12, 10, 12, 10)   ->  `12:10:00`
-    """
-    return any(
-        datetime_index.to_series().dt.time != pd.Timestamp("00:00:00").time()
-    )
-
-
-def get_DataFrame(file) -> pd.DataFrame:
-    return pd.read_csv(
-        file, index_col="Date", parse_dates=["Date"], na_filter=False
-    )
-
-
 def csv_loader(
     file_path: Path,
     period=160,


### PR DESCRIPTION
This PR brings performance improvements to both plotting and scanning. CSV files are only partially loaded into memory.
Use of `functools.lru_cache` improves chart switching performance by caching the DataFrame.
A lot of error handling code has been removed further improving code clarity and performance.

306636b - Removed functions not required in utils.py

b472633 - Use csv_loader in scan_patterns and remove old code

8d99dd6 - Add lru_cache to improve performance when switching charts

0e2ef84 - Replace Union types with Optional

077e72e 
    - Use csv_loader function in Plotter.py
    - Removed some error handling code not required anymore 
    - Removed some unused code

1a3e369 - Added csv_loader function for fast chunked loading of CSV