### PR TITLE
Dev v3.0.1

### DIFF
--- a/src/backtest.py
+++ b/src/backtest.py
@@ -129,12 +129,7 @@ def scan(
 
     df = loader.get(sym)
 
-    if (
-        df is None
-        or df.empty
-        or end is not None
-        and (end < df.index[0] or end > df.index[-1])
-    ):
+    if df is None or df.empty or end is not None and end < df.index[0]:
         return results
 
     assert isinstance(df.index, pd.DatetimeIndex)

--- a/src/init.py
+++ b/src/init.py
@@ -17,7 +17,7 @@ except ModuleNotFoundError:
     exit("tqdm is required. Run `pip install tqdm` to install")
 
 
-version = "3.0.0"
+version = "3.0.1"
 
 futures: List[concurrent.futures.Future] = []
 


### PR DESCRIPTION
a5c8082 (HEAD -> dev) Bump to version 3.0.1
ef55d48 - Fix: Removed boundary check at end of dataframe causing scan to be skipped

Issue relates to using backtest.py with intraday data. When using `-d` option passing only date value and no time data, the scan is skipped.