### PR TITLE
Dev 3.1.3

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -271,7 +271,7 @@ def process(
 # Differentiate between the main thread and child threads on Windows
 # see https://stackoverflow.com/a/57811249
 if __name__ == "__main__":
-    version = "3.1.2"
+    version = "3.1.3"
 
     futures: List[concurrent.futures.Future] = []
 

--- a/src/init.py
+++ b/src/init.py
@@ -486,22 +486,30 @@ if __name__ == "__main__":
         if meta["end_date"]:
             end_date = datetime.fromisoformat(meta["end_date"])
 
-        loader = getattr(loader_module, loader_name)(
-            config,
-            meta["timeframe"],
-            end_date=end_date,
-        )
+        try:
+            loader = getattr(loader_module, loader_name)(
+                config,
+                meta["timeframe"],
+                end_date=end_date,
+            )
+        except ValueError as e:
+            logger.exception(e, exc_info=e)
+            exit()
 
         plotter = Plotter(data, loader)
         plotter.plot(args.idx)
         cleanup(loader, futures)
         exit()
 
-    loader = getattr(loader_module, loader_name)(
-        config,
-        args.tf,
-        end_date=args.date,
-    )
+    try:
+        loader = getattr(loader_module, loader_name)(
+            config,
+            args.tf,
+            end_date=args.date,
+        )
+    except ValueError as e:
+        logger.exception(e, exc_info=e)
+        exit()
 
     fn_dict: Dict[str, Union[str, Callable]] = {
         "all": "all",

--- a/src/init.py
+++ b/src/init.py
@@ -78,7 +78,11 @@ def scan_pattern(
         return patterns
 
     if df.index.has_duplicates:
-        df = df[~df.index.duplicated()]
+        df = df.loc[~df.index.duplicated()]
+
+    # Reverse datetime order if descending (Newest to oldest)
+    if df.index.is_monotonic_decreasing:
+        df = df.loc[::-1]
 
     pivots = utils.get_max_min(df, barsLeft=bars_left, barsRight=bars_right)
 

--- a/src/loaders/IEODFileLoader.py
+++ b/src/loaders/IEODFileLoader.py
@@ -53,19 +53,16 @@ class IEODFileLoader(AbstractLoader):
         self.default_tf = str(config.get("DEFAULT_TF", "1"))
         self.end_date = end_date
 
-        if self.default_tf not in self.timeframes:
-            valid_values = ", ".join(self.timeframes.keys())
+        valid_values = ", ".join(self.timeframes.keys())
 
+        if self.default_tf not in self.timeframes:
             raise ValueError(
                 f"`DEFAULT_TF` in config must be one of {valid_values}"
             )
 
         if tf is None:
             tf = self.default_tf
-
-        if not tf in self.timeframes:
-            valid_values = ", ".join(self.timeframes.keys())
-
+        elif tf not in self.timeframes:
             raise ValueError(f"Timeframe must be one of {valid_values}")
 
         self.tf = tf

--- a/src/loaders/utils.py
+++ b/src/loaders/utils.py
@@ -7,6 +7,22 @@ import io
 import os
 
 
+def process_df(df: pd.DataFrame, end_date: Optional[datetime], period: int):
+    if end_date:
+        df = df.loc[:end_date]
+
+    if len(df) < period:
+        return df
+
+    dt = df.index[-period]
+
+    assert isinstance(dt, pd.Timestamp)
+
+    dt = dt.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    return df.loc[dt:]
+
+
 @lru_cache(maxsize=6)
 def csv_loader(
     file_path: Path,
@@ -68,7 +84,7 @@ def csv_loader(
             if not df.empty and end_date < dt:
                 raise IndexError("Date out of bounds of current DataFrame")
 
-            return df.loc[:end_date].iloc[-period:]
+            return process_df(df, end_date, period)
 
         return df.iloc[-period:]
 
@@ -177,6 +193,6 @@ def csv_loader(
     )
 
     if end_date:
-        return df.loc[:end_date].iloc[-period:]
+        return process_df(df, end_date, period)
     else:
-        return df.iloc[-period:]
+        return process_df(df, None, period)

--- a/src/loaders/utils.py
+++ b/src/loaders/utils.py
@@ -60,7 +60,12 @@ def csv_loader(
         )
 
         if end_date:
-            if not df.empty and end_date < df.index[0]:
+            dt = df.index[0]
+
+            if isinstance(dt, pd.Timestamp) and dt.tzinfo:
+                end_date = end_date.replace(tzinfo=dt.tzinfo)
+
+            if not df.empty and end_date < dt:
                 raise IndexError("Date out of bounds of current DataFrame")
 
             return df.loc[:end_date].iloc[-period:]

--- a/src/utils.py
+++ b/src/utils.py
@@ -862,11 +862,7 @@ def find_triangles(
         if triangle is not None:
             # check if high of C or low of D has been breached
             # Check if A is indeed the pivot high
-            if (
-                a == df.at[a_idx, "Low"]
-                or c_idx != df.loc[c_idx:, "Close"].idxmax()
-                or d_idx != df.loc[d_idx:, "Close"].idxmin()
-            ):
+            if a == df.at[a_idx, "Low"]:
                 a_idx, a = c_idx, c
                 continue
 
@@ -890,6 +886,17 @@ def find_triangles(
             if triangle == "Symmetric" and (
                 upper.slope > -0.2 and lower.slope < 0.2
             ):
+                break
+
+            # Check if trendlines have been breached
+            pos = df.reset_index().index
+
+            # calculate the y-axis price for every point on the slope
+            upper_slope = upper.slope * pos + upper.y_int
+            lower_slope = lower.slope * pos + lower.y_int
+
+            # Check if close has violated the upper or lower trendline
+            if (df.Close > upper_slope).any() or (df.Close < lower_slope).any():
                 break
 
             logger.debug(f"{sym} - {triangle}")

--- a/src/utils.py
+++ b/src/utils.py
@@ -441,7 +441,7 @@ def find_bullish_vcp(
         c = pivots.at[c_idx, "P"]
 
         df_slice = df.loc[a_idx:c_idx]
-        avgBarLength = (df_slice["High"] - df_slice["Low"]).mean()
+        avgBarLength = (df_slice["High"] - df_slice["Low"]).median()
 
         if pivots.index.has_duplicates:
             if isinstance(a, (pd.Series, str)):
@@ -537,7 +537,7 @@ def find_bearish_vcp(
         c = pivots.at[c_idx, "P"]
 
         df_slice = df.loc[a_idx:c_idx]
-        avgBarLength = (df_slice["High"] - df_slice["Low"]).mean()
+        avgBarLength = (df_slice["High"] - df_slice["Low"]).median()
 
         if pivots.index.has_duplicates:
             if isinstance(a, (pd.Series, str)):
@@ -642,7 +642,7 @@ def find_double_bottom(
                 cVol = pivots.at[c_idx, "V"].iloc[1]
 
         df_slice = df.loc[a_idx:c_idx]
-        avgBarLength = (df_slice["High"] - df_slice["Low"]).mean()
+        avgBarLength = (df_slice["High"] - df_slice["Low"]).median()
 
         if is_double_bottom(a, b, c, d, aVol, cVol, avgBarLength, atr):
             if (
@@ -741,7 +741,7 @@ def find_double_top(
                 cVol = pivots.at[c_idx, "V"].iloc[0]
 
         df_slice = df.loc[a_idx:c_idx]
-        avgBarLength = (df_slice["High"] - df_slice["Low"]).mean()
+        avgBarLength = (df_slice["High"] - df_slice["Low"]).median()
 
         if is_double_top(a, b, c, d, aVol, cVol, avgBarLength, atr):
             if (
@@ -855,7 +855,7 @@ def find_triangles(
                 e = pivots.at[e_idx, "P"].iloc[0]
 
         df_slice = df.loc[a_idx:d_idx]
-        avgBarLength = (df_slice["High"] - df_slice["Low"]).mean()
+        avgBarLength = (df_slice["High"] - df_slice["Low"]).median()
 
         triangle = is_triangle(a, b, c, d, e, f, avgBarLength)
 
@@ -976,7 +976,7 @@ def find_hns(
                 e = pivots.at[e_idx, "P"].iloc[0]
 
         df_slice = df.loc[b_idx:d_idx]
-        avgBarLength = (df_slice["High"] - df_slice["Low"]).mean()
+        avgBarLength = (df_slice["High"] - df_slice["Low"]).median()
 
         if is_hns(a, b, c, d, e, f, avgBarLength):
             if (
@@ -1118,7 +1118,7 @@ def find_reverse_hns(
                 e = pivots.loc[e_idx, "P"].iloc[1]
 
         df_slice = df.loc[b_idx:d_idx]
-        avgBarLength = (df_slice["High"] - df_slice["Low"]).mean()
+        avgBarLength = (df_slice["High"] - df_slice["Low"]).median()
 
         if is_reverse_hns(a, b, c, d, e, f, avgBarLength):
             if (


### PR DESCRIPTION
## Highlights

- Reject a Triangle pattern, if its trendline is violated on a closing basis.
- Use median instead of mean average to calculate candle size. This ensures exceptionally large candles doesn't skew the average candle size.

### UX improvement
- If the dates are not in correct order (Oldest to Newest), reverse the DataFrame and correct it.
- Additional validations when using IEODFileLoader class.
    - Check if TF is less than default timeframe. (No downsampling of Data).
    - Check if resampling can be performed accurately given the default timeframe.

### Fixes
- Fix: Ensure adequate candles are loaded for resample operations.
- Fix: Correctly resample 25, 75 and 125 min timeframes.
- Fix: Timezone related error in `loaders/utils.py.csv_loader`.

144edb2 (HEAD -> dev) Added custom function to resample 25, 75 and 125 min correctly.
cd77dca Modified csv_loader to load data from start of day
528b2c4 Check end_date is timezone aware, when filesize less than chunksize.
37a0d31 Added function to calculate the lines to load from file during resample.
83ec774 Moved valid_values outside if block to minimize duplication.
8ae2556 Catch and log ValueError on initializing Loader
22c2637 Bump to version 3.1.3
79e3cb3 Removed date order check in setup-config.py.
cd33645 Skip triangle pattern if trendline has been violated on closing basis.
3ecc332 Use median instead of mean to calculate candle size average.
b9dba27 Reverse the DataFrame if index is in descending order
