### PR TITLE
Dev v3.1.8 

### DIFF
--- a/src/init.py
+++ b/src/init.py
@@ -271,7 +271,7 @@ def process(
 # Differentiate between the main thread and child threads on Windows
 # see https://stackoverflow.com/a/57811249
 if __name__ == "__main__":
-    version = "3.1.7"
+    version = "3.1.8"
 
     futures: List[concurrent.futures.Future] = []
 

--- a/src/loaders/IEODFileLoader.py
+++ b/src/loaders/IEODFileLoader.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import pandas as pd
 
@@ -52,6 +52,7 @@ class IEODFileLoader(AbstractLoader):
 
         # Default timeframe is 1 min.
         self.default_tf = str(config.get("DEFAULT_TF", "1"))
+        self.is_24_7 = config.get("24_7", False)
         self.end_date = end_date
 
         valid_values = ", ".join(self.timeframes.keys())
@@ -100,6 +101,9 @@ class IEODFileLoader(AbstractLoader):
         if self.tf == self.default_tf or df.empty:
             return df
 
+        if not self.is_24_7 and self.tf in ("25", "75", "125"):
+            return self._resample_df(df, self.offset_str, self.ohlc_dict)
+
         df = (
             df.resample(self.offset_str, origin="start")
             .agg(self.ohlc_dict)
@@ -137,3 +141,36 @@ class IEODFileLoader(AbstractLoader):
             )
 
         return tf // default_tf * period
+
+    @staticmethod
+    def _resample_df(
+        df: pd.DataFrame,
+        target_tf: str,
+        ohlc_dict: Dict[str, str],
+    ) -> pd.DataFrame:
+        """
+        Resample 25, 75 and 125 mins
+        """
+        lst = []
+        dt = None
+
+        while dt is None or dt <= df.index[-1]:
+            dt = df.index[0] if dt is None else dt + pd.Timedelta(days=1)
+
+            if dt not in df.index:
+                continue
+
+            slice_df = df.loc[
+                dt : dt.replace(
+                    hour=23,
+                    minute=59,
+                    second=59,
+                    microsecond=10**6 - 1,
+                )
+            ]
+
+            lst.append(
+                slice_df.resample(target_tf, origin="start").agg(ohlc_dict)
+            )
+
+        return pd.concat(lst).dropna()

--- a/src/loaders/IEODFileLoader.py
+++ b/src/loaders/IEODFileLoader.py
@@ -68,7 +68,7 @@ class IEODFileLoader(AbstractLoader):
 
         self.tf = tf
         self.offset_str = self.timeframes[tf]
-        self.period = period
+        self.period = self._get_period(period)
 
         self.data_path = Path(config["DATA_PATH"]).expanduser()
 
@@ -113,3 +113,27 @@ class IEODFileLoader(AbstractLoader):
     def close(self):
         """Not required as nothing to close"""
         pass
+
+    def _get_period(self, period: int) -> int:
+        if "h" in self.tf:
+            tf = int(self.tf[:-1]) * 60
+        else:
+            tf = int(self.tf)
+
+        if "h" in self.default_tf:
+            default_tf = int(self.default_tf[:-1]) * 60
+        else:
+            default_tf = int(self.default_tf)
+
+        if tf == default_tf:
+            return period
+
+        if tf < default_tf:
+            raise ValueError("Timeframe cannot be less than default timeframe.")
+
+        if tf % default_tf != 0:
+            raise ValueError(
+                f"Resampling {default_tf}min to {tf}min wont be accurate."
+            )
+
+        return tf // default_tf * period

--- a/src/loaders/IEODFileLoader.py
+++ b/src/loaders/IEODFileLoader.py
@@ -54,19 +54,16 @@ class IEODFileLoader(AbstractLoader):
         self.default_tf = str(config.get("DEFAULT_TF", "1"))
         self.end_date = end_date
 
-        if self.default_tf not in self.timeframes:
-            valid_values = ", ".join(self.timeframes.keys())
+        valid_values = ", ".join(self.timeframes.keys())
 
+        if self.default_tf not in self.timeframes:
             raise ValueError(
                 f"`DEFAULT_TF` in config must be one of {valid_values}"
             )
 
         if tf is None:
             tf = self.default_tf
-
-        if not tf in self.timeframes:
-            valid_values = ", ".join(self.timeframes.keys())
-
+        elif tf not in self.timeframes:
             raise ValueError(f"Timeframe must be one of {valid_values}")
 
         self.tf = tf

--- a/src/loaders/utils.py
+++ b/src/loaders/utils.py
@@ -133,7 +133,6 @@ def csv_loader(
                     # Count N periods from end_date
                     if lines_read >= period:
                         chunks_read.append(chunk[start + 1 :])
-                        chunks_read.append(columns)
                         break
 
                     chunks_read.append(chunk)
@@ -150,7 +149,6 @@ def csv_loader(
                 if lines_read >= period:
                     start = chunk.find(b"\n") + 1
                     chunks_read.append(chunk[start:])
-                    chunks_read.append(columns)
                     break
 
                 # we are storing the chunks in bottom first order.
@@ -165,6 +163,7 @@ def csv_loader(
 
         # Reverse the list and join it into a bytes string.
         # Store the result in a buffer
+        chunks_read.append(columns)
         buffer = io.BytesIO(b"".join(chunks_read[::-1]))
 
     df = pd.read_csv(

--- a/src/utils.py
+++ b/src/utils.py
@@ -862,9 +862,7 @@ def find_triangles(
 
         if triangle is not None:
             # Check if A is indeed the pivot high
-            if (
-                a == df.at[a_idx, "Low"]
-            ):
+            if a == df.at[a_idx, "Low"]:
                 a_idx, a = c_idx, c
                 continue
 


### PR DESCRIPTION
This update is focused on fixes to `IEODFileLoader` for intraday timeframes and a fix for missing column headers that was missed in the previous update.

02f6582 (HEAD -> dev) Bump to version 3.1.8
a079cc1 
- Added new config value `24_7` to provide hint about market hours. 
- Resampling of 25, 75, 125 mins is made more accurate.

d8774be Add `_get_period` method to calculate period (lines) to load on intraday tf.
7aa50b9 Added validation checks to IEODFileLoader
6133483 Append column headers only after loop is broken
e5c70c5 Minor code formatting in src/utils.py