### PR TITLE
Dev v4.0.3

### DIFF
--- a/src/Plotter.py
+++ b/src/Plotter.py
@@ -73,7 +73,11 @@ class Plotter:
 
         dct = self.data[self.idx]
         sym = dct["sym"].upper()
-        pattern = dct["pattern"]
+
+        if "alt_name" in dct:
+            pattern = dct["alt_name"]
+        else:
+            pattern = dct["pattern"]
 
         df = self.loader.get(sym)
 

--- a/src/Plotter.py
+++ b/src/Plotter.py
@@ -315,18 +315,24 @@ class Plotter:
         for label, point in points.items():
             x, y = point
 
-            if not xmin:
-                xmin = self.df.index.get_loc(x)
-
-            hline_levels.append(y)
-
             if label == "direction":
-                colors.append(self.config.get("BIAS_LINE_COLOR", "green"))
-                continue
+                self.main_ax.hlines(
+                    y,
+                    self.df.index.get_loc(x),
+                    xmax,
+                    colors=self.config.get("BIAS_LINE_COLOR", "green"),
+                )
+            else:
+                if not xmin:
+                    xmin = self.df.index.get_loc(x)
 
-            colors.append(self.line_color)
+                hline_levels.append(y)
 
-            self._annotate_fn(text=label, xy=(xmin, y), xytext=(10, -10))
+                colors.append(self.line_color)
+
+                self._annotate_fn(
+                    text=f"{label} - {y:.2f}", xy=(xmin, y), xytext=(10, -10)
+                )
 
         self.main_ax.hlines(hline_levels, xmin, xmax, colors=colors)
 

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -70,6 +70,10 @@ def parse_cli_args():
         "abcdd",
         "batu",
         "batd",
+        "garu",
+        "gard",
+        "crabu",
+        "crabd",
     )
 
     parser = argparse.ArgumentParser(description="Run backdated pattern scan")
@@ -190,6 +194,10 @@ def scan(
         "abcdd": utils.find_bearish_abcd,
         "batu": utils.find_bullish_bat,
         "batd": utils.find_bearish_bat,
+        "garu": utils.find_bullish_gartley,
+        "gard": utils.find_bearish_gartley,
+        "crabu": utils.find_bullish_crab,
+        "crabd": utils.find_bearish_crab,
     }
 
     df = loader.get(sym)

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -46,6 +46,15 @@ py backtest.py -p trng --date 2023-12-01 --period 60
 """
 
 
+def uncaught_exception_handler(*args):
+    """
+    Handle all Uncaught Exceptions
+
+    Function passed to sys.excepthook
+    """
+    logger.critical("Uncaught Exception", exc_info=args)
+
+
 def parse_cli_args():
     key_list = (
         "vcpu",
@@ -334,6 +343,7 @@ if __name__ == "__main__":
 
     logger = logging.getLogger(__name__)
 
+    sys.excepthook = uncaught_exception_handler
     DIR = Path(__file__).parent
 
     if "-c" in sys.argv or "--config" in sys.argv:

--- a/src/init.py
+++ b/src/init.py
@@ -342,7 +342,7 @@ def process(
 # Differentiate between the main thread and child threads on Windows
 # see https://stackoverflow.com/a/57811249
 if __name__ == "__main__":
-    version = "4.0.2"
+    version = "4.0.3"
 
     futures: List[concurrent.futures.Future] = []
 

--- a/src/init.py
+++ b/src/init.py
@@ -6,7 +6,9 @@ import sys
 from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Tuple, Union
+from typing import Callable, Dict, List, Optional, Tuple
+
+import questionary
 
 import utils
 from loaders.AbstractLoader import AbstractLoader
@@ -28,35 +30,69 @@ def uncaught_exception_handler(*args):
     cleanup(loader, futures)
 
 
-def get_user_input() -> str:
-    user_input = input(
-        """
-    Enter a number to select a pattern.
+def get_user_selection() -> Optional[str]:
+    while True:
+        ptn_key = questionary.select(
+            message="Select an option [ ** Excludes Trendlines & Triangles ]",
+            choices=[
+                questionary.Choice("[ALL] Scan All", value="all"),
+                questionary.Choice("[BULL] Scan only Bull **", value="bull"),
+                questionary.Choice("[BEAR] Scan only Bear **", value="bear"),
+                questionary.Choice(
+                    "[TRNG] Triangles (Symetrical, Ascending, Descending)",
+                    value="trng",
+                ),
+                questionary.Choice("[UPTL] Uptrend lines", value="uptl"),
+                questionary.Choice("[DNTL] Downtrend lines", value="dntl"),
+                questionary.Choice("SELECT BULL pattern", value="SELECT_BULL"),
+                questionary.Choice("SELECT BEAR pattern", value="SELECT_BEAR"),
+            ],
+            use_shortcuts=True,
+        ).ask()
 
-    0.  ALL   - Scan all patterns
-    1:  BULL  - All Bullish patterns
-    2:  BEAR  - All Bearish patterns
-    3.  VCPU  - Bullish VCP (Volatility Contraction pattern)
-    4.  VCPD  - Bearish VCP
-    5.  DBOT  - Double Bottom (Bullish)
-    6.  DTOP  - Double Top (Bearish)
-    7.  HNSD  - Head and Shoulder
-    8.  HNSU  - Reverse Head and Shoulder
-    9.  TRNG  - Triangles (Symmetrical, Ascending, Descending)
-    10. UPTL  - Uptrend line
-    11. DNTL  - Downtrend line
-    12. ABCDU - AB=CD Bullish Harmonic pattern (EXPERIMENTAL - WIP)
-    13. ABCDD - AB=CD Bearish Harmonic pattern (EXPERIMENTAL - WIP)
-    14. BATU  - Bullish BAT Harmonic pattern (EXPERIMENTAL - WIP)
-    15. BATD  - Bearish BAT Harmonic pattern (EXPERIMENTAL - WIP)
-    > """
-    )
+        if ptn_key == "SELECT_BULL":
+            ptn_key = questionary.select(
+                message="Select a BULL pattern",
+                choices=[
+                    questionary.Choice(
+                        "[VCPU] Volatility Contraction", value="vcpu"
+                    ),
+                    questionary.Choice("[DBOT] Double Bottom", value="dbot"),
+                    questionary.Choice("[HSNU] Head & Shoulders", value="hnsu"),
+                    questionary.Choice("[ABCDU] AB=CD Harmonic", value="abcdu"),
+                    questionary.Choice("[BATU] BAT Harmonic", value="batu"),
+                    questionary.Choice(
+                        "[GARTU] Gartley Harmonic", value="gartu"
+                    ),
+                    questionary.Choice("[CRABU] Crab Harmonic", value="crabu"),
+                    questionary.Choice("Back to main", value="MAIN"),
+                ],
+                use_shortcuts=True,
+            ).ask()
+        elif ptn_key == "SELECT_BEAR":
+            ptn_key = questionary.select(
+                message="Select a BEAR pattern",
+                choices=[
+                    questionary.Choice(
+                        "[VCPD] Volatility Contraction", value="vcpd"
+                    ),
+                    questionary.Choice("[DTOP] Double Top", value="dtop"),
+                    questionary.Choice("[HNSD] Head & Shoulders", value="hnsd"),
+                    questionary.Choice("[ABCDD] AB=CD Harmonic", value="abcdd"),
+                    questionary.Choice("[BATD] BAT Harmonic", value="batd"),
+                    questionary.Choice(
+                        "[GARTD] Gartley Harmonic", value="gartd"
+                    ),
+                    questionary.Choice("[CRABD] Crab Harmonic", value="crabd"),
+                    questionary.Choice("Back to main", value="MAIN"),
+                ],
+                use_shortcuts=True,
+            ).ask()
 
-    if not (user_input.isdigit() and int(user_input) in range(16)):
-        print("Enter a key from the list")
-        return get_user_input()
+        if ptn_key == "MAIN":
+            continue
 
-    return user_input
+        return ptn_key
 
 
 def get_loader_class(config):
@@ -322,28 +358,29 @@ if __name__ == "__main__":
     # Load configuration
     DIR = Path(__file__).parent
 
-    key_list = (
-        "all",
-        "bull",
-        "bear",
-        "vcpu",
-        "vcpd",
-        "dbot",
-        "dtop",
-        "hnsd",
-        "hnsu",
-        "trng",
-        "uptl",
-        "dntl",
-        "abcdu",
-        "abcdd",
-        "batu",
-        "batd",
-    )
+    fn_dict: Dict[str, Callable] = {
+        "vcpu": utils.find_bullish_vcp,
+        "dbot": utils.find_double_bottom,
+        "hnsu": utils.find_reverse_hns,
+        "vcpd": utils.find_bearish_vcp,
+        "dtop": utils.find_double_top,
+        "hnsd": utils.find_hns,
+        "trng": utils.find_triangles,
+        "uptl": utils.find_uptrend_line,
+        "dntl": utils.find_downtrend_line,
+        "abcdu": utils.find_bullish_abcd,
+        "abcdd": utils.find_bearish_abcd,
+        "batu": utils.find_bullish_bat,
+        "batd": utils.find_bearish_bat,
+        "gartu": utils.find_bullish_gartley,
+        "gartd": utils.find_bearish_gartley,
+        "crabu": utils.find_bullish_crab,
+        "crabd": utils.find_bearish_crab,
+    }
 
     # Parse CLI arguments
     parser = ArgumentParser(
-        description="Python CLI tool to identify common Chart patterns",
+        description="Python CLI tool to identify common Chart patterns. Includes Harmonic chart patterns.",
         epilog="https://github.com/BennyThadikaran/stock-pattern",
     )
 
@@ -375,8 +412,8 @@ if __name__ == "__main__":
         "--pattern",
         type=str,
         metavar="str",
-        choices=key_list,
-        help=f"String pattern. One of {', '.join(key_list)}",
+        choices=fn_dict.keys(),
+        help=f"String pattern. One of {', '.join(fn_dict.keys())}",
     )
 
     parser.add_argument(
@@ -538,39 +575,16 @@ if __name__ == "__main__":
         logger.exception("", exc_info=e)
         exit()
 
-    fn_dict: Dict[str, Union[str, Callable]] = {
-        "all": "all",
-        "bull": "bull",
-        "bear": "bear",
-        "vcpu": utils.find_bullish_vcp,
-        "dbot": utils.find_double_bottom,
-        "hnsu": utils.find_reverse_hns,
-        "vcpd": utils.find_bearish_vcp,
-        "dtop": utils.find_double_top,
-        "hnsd": utils.find_hns,
-        "trng": utils.find_triangles,
-        "uptl": utils.find_uptrend_line,
-        "dntl": utils.find_downtrend_line,
-        "abcdu": utils.find_bullish_abcd,
-        "abcdd": utils.find_bearish_abcd,
-        "batu": utils.find_bullish_bat,
-        "batd": utils.find_bearish_bat,
-    }
-
     if args.pattern:
-        key: str = args.pattern
+        key = args.pattern
     else:
-        try:
-            user_input = get_user_input()
-        except KeyboardInterrupt:
+        key = get_user_selection()
+
+        if key is None:
             cleanup(loader, futures)
             exit()
 
-        key = key_list[int(user_input)]
-
         args.pattern = key
-
-    fn = fn_dict[key]
 
     logger.info(
         f"Scanning `{key.upper()}` patterns on `{loader.tf}`. Press Ctrl - C to exit"
@@ -580,24 +594,18 @@ if __name__ == "__main__":
 
     patterns: List[dict] = []
 
-    if callable(fn):
-        fns = (fn,)
-    elif fn == "bull":
-        bull_list = ("vcpu", "hnsu", "dbot")
+    if key in fn_dict:
+        fns = (fn_dict[key],)
+    elif key == "bull":
+        bull_list = ("vcpu", "hnsu", "dbot", "abcdu", "batu", "crabu", "gartu")
 
-        fns = tuple(
-            v for k, v in fn_dict.items() if k in bull_list and callable(v)
-        )
-    elif fn == "bear":
-        bear_list = ("vcpd", "hnsd", "dtop")
+        fns = tuple(v for k, v in fn_dict.items() if k in bull_list)
+    elif key == "bear":
+        bear_list = ("vcpd", "hnsd", "dtop", "abcdd", "batd", "crabd", "gartd")
 
-        fns = tuple(
-            v for k, v in fn_dict.items() if k in bear_list and callable(v)
-        )
+        fns = tuple(v for k, v in fn_dict.items() if k in bear_list)
     else:
-        fns = tuple(
-            v for k, v in fn_dict.items() if k in key_list[3:10] and callable(v)
-        )
+        fns = tuple(v for k, v in fn_dict.items() if k in list(fn_dict.keys()))
 
     try:
         patterns = process(data, key, fns, futures)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1508,7 +1508,7 @@ def find_bullish_abcd(
     Bullish AB = CD harmonic pattern
     """
 
-    alt_name = ""
+    alt_name = "Bull AB=CD"
     pivot_len = pivots.shape[0]
 
     a_idx = pivots["P"].idxmax()
@@ -1614,7 +1614,7 @@ def find_bullish_abcd(
             )
 
             if is_perfect:
-                alt_name = "BULL Perfect AB=CD"
+                alt_name = "Bull Perfect AB=CD"
 
                 selected["extra_points"].update(
                     {
@@ -1623,7 +1623,7 @@ def find_bullish_abcd(
                     }
                 )
             elif is_alternate:
-                alt_name = "BULL Alternate AB=CD"
+                alt_name = "Bull Alternate AB=CD"
 
                 selected["extra_points"].update(
                     {
@@ -1632,8 +1632,6 @@ def find_bullish_abcd(
                     }
                 )
             else:
-                alt_name = "BULL AB=CD"
-
                 selected["extra_points"].update(
                     {
                         f"{c_fib_inverse:.3f}BC": (b_idx, bc_ext),
@@ -1662,7 +1660,7 @@ def find_bearish_abcd(
     Bearish AB = CD harmonic pattern
     """
 
-    alt_name = ""
+    alt_name = "Bear AB=CD"
     pivot_len = pivots.shape[0]
 
     a_idx = pivots["P"].idxmin()
@@ -1769,7 +1767,7 @@ def find_bearish_abcd(
             )
 
             if is_perfect:
-                alt_name = "BEAR Perfect AB=CD"
+                alt_name = "Bear Perfect AB=CD"
 
                 selected["extra_points"].update(
                     {
@@ -1778,7 +1776,7 @@ def find_bearish_abcd(
                     }
                 )
             elif is_alternate:
-                alt_name = "BEAR Alternate AB=CD"
+                alt_name = "Bear Alternate AB=CD"
 
                 selected["extra_points"].update(
                     {
@@ -1787,8 +1785,6 @@ def find_bearish_abcd(
                     }
                 )
             else:
-                alt_name = "BEAR AB=CD"
-
                 selected["extra_points"].update(
                     {
                         f"{c_fib_inverse:.3f}BC": (b_idx, bc_ext),
@@ -1967,7 +1963,7 @@ def find_bullish_bat(
                 )
             elif is_alternate_bat:
                 # Alternate BAT pattern
-                alt_name = "BULL Alternate BAT"
+                alt_name = "Bull Alternate BAT"
 
                 selected["extra_points"].update(
                     {
@@ -2090,7 +2086,7 @@ def find_bearish_bat(
 
         highest_close_after_b = df.loc[b_idx:, "Close"].max()
         lowest_low_after_c = df.loc[c_idx:, "Low"].min()
-        
+
         if is_perfect_bat:
             terminal_point = max(ab_27_ext, bc_2_ext)
         elif is_alternate_bat:
@@ -2115,7 +2111,7 @@ def find_bearish_bat(
         ).sum()
 
         if (
-            d >= terminal_point 
+            d >= terminal_point
             and closes_above_terminal_point < 7
             and d == highest_close_after_b
             and c == lowest_low_after_c

--- a/src/utils.py
+++ b/src/utils.py
@@ -1548,7 +1548,6 @@ def find_bullish_abcd(
 
         bc_diff = c - b
         ab_diff = a - b
-        c_retrace = bc_diff / ab_diff
 
         if (
             a == df.at[a_idx, "Low"]
@@ -1560,13 +1559,14 @@ def find_bullish_abcd(
             continue
 
         # Get the FIB ratio nearest to point C
-        c_nearest_fib = fib_ser.loc[(fib_ser - c_retrace).abs().idxmin()]
+        c_retrace = fib_ser.loc[(fib_ser - (bc_diff / ab_diff)).abs().idxmin()]
+
 
         if c_retrace < 0.382 or c_retrace > 0.886:
             a, a_idx = c, c_idx
             continue
 
-        c_fib_inverse = 1 / c_nearest_fib
+        c_fib_inverse = 1 / c_retrace
 
         ab_cd_ext = c - ab_diff
         bc_ext = c - bc_diff * c_fib_inverse
@@ -1671,7 +1671,6 @@ def find_bearish_abcd(
 
         bc_diff = b - c
         ab_diff = b - a
-        c_retrace = bc_diff / ab_diff
 
         if (
             a == df.at[a_idx, "High"]
@@ -1683,13 +1682,13 @@ def find_bearish_abcd(
             continue
 
         # Get the FIB ratio nearest to point C
-        c_nearest_fib = fib_ser.loc[(fib_ser - c_retrace).abs().idxmin()]
+        c_retrace = fib_ser.loc[(fib_ser - (bc_diff / ab_diff)).abs().idxmin()]
 
         if c_retrace < 0.382 or c_retrace > 0.886:
             a, a_idx = c, c_idx
             continue
 
-        c_fib_inverse = 1 / c_nearest_fib
+        c_fib_inverse = 1 / c_retrace
 
         ab_cd_ext = c + ab_diff
         bc_ext = c + bc_diff * c_fib_inverse

--- a/src/utils.py
+++ b/src/utils.py
@@ -1786,7 +1786,7 @@ def find_bullish_bat(
         bc_618_ext = c - bc_diff * 1.618
         lowest_close_after_b = df.loc[b_idx:, "Close"].min()
 
-        if d < b and lowest_close_after_b > x and d == lowest_close_after_b:
+        if d <= bc_618_ext and lowest_close_after_b > x and d == lowest_close_after_b:
 
             if (
                 x == df.at[x_idx, "High"]
@@ -1905,7 +1905,7 @@ def find_bearish_bat(
         bc_618_ext = c + bc_diff * 1.618
         highest_close_after_b = df.loc[b_idx:, "Close"].max()
 
-        if d > b and highest_close_after_b < x and d == highest_close_after_b:
+        if d >= bc_618_ext and highest_close_after_b < x and d == highest_close_after_b:
 
             if (
                 x == df.at[x_idx, "Low"]

--- a/src/utils.py
+++ b/src/utils.py
@@ -1813,15 +1813,12 @@ def find_bullish_bat(
         is_perfect_bat = b_retrace == 0.5 and (
             c_retrace == 0.5 or c_retrace == 0.618
         )
+
         is_alternate_bat = b_retrace == 0.382
 
         xa_886_retrace = a - xa_diff * 0.886
-
-        bc_618_ext = c - bc_diff * 1.618
         bc_2_ext = c - bc_diff * 2
         xa_13_ext = c - xa_diff * 1.13
-        ab_27_ext = c - ab_diff * 1.27
-        ab_618_ext = c - ab_diff * 1.618
 
         lowest_close_after_b = df.loc[b_idx:, "Close"].min()
 
@@ -1869,7 +1866,7 @@ def find_bullish_bat(
 
                 selected["extra_points"].update(
                     {
-                        "1.27AB=CD": (b_idx, ab_27_ext),
+                        "1.27AB=CD": (b_idx, c - ab_diff * 1.27),
                         "2BC": (b_idx, bc_2_ext),
                     }
                 )
@@ -1898,7 +1895,7 @@ def find_bullish_bat(
                 selected["extra_points"].update(
                     {
                         "0.886XA": (b_idx, xa_886_retrace),
-                        "1.618BC": (b_idx, bc_618_ext),
+                        "1.618BC": (b_idx, c - bc_diff * 1.618),
                     }
                 )
 
@@ -1906,13 +1903,7 @@ def find_bullish_bat(
         x = pivots.loc[x_idx, "P"]
 
     if selected:
-        selected.update(
-            dict(
-                sym=sym,
-                pattern="BATU",
-                alt_name=alt_name
-            )
-        )
+        selected.update(dict(sym=sym, pattern="BATU", alt_name=alt_name))
 
     return selected
 
@@ -2005,12 +1996,8 @@ def find_bearish_bat(
         is_alternate_bat = b_retrace == 0.382
 
         xa_886_retrace = a + xa_diff * 0.886
-
-        bc_618_ext = c + bc_diff * 1.618
         bc_2_ext = c + bc_diff * 2
         xa_13_ext = c + xa_diff * 1.13
-        ab_27_ext = c + ab_diff * 1.27
-        ab_618_ext = c + ab_diff * 1.618
 
         highest_close_after_b = df.loc[b_idx:, "Close"].max()
 
@@ -2048,7 +2035,7 @@ def find_bearish_bat(
 
                 selected["extra_points"].update(
                     {
-                        "1.27AB=CD": (b_idx, ab_27_ext),
+                        "1.27AB=CD": (b_idx, c + ab_diff * 1.27),
                         "2BC": (b_idx, bc_2_ext),
                     }
                 )
@@ -2079,7 +2066,7 @@ def find_bearish_bat(
                 selected["extra_points"].update(
                     {
                         "0.886XA": (b_idx, xa_886_retrace),
-                        "1.618BC": (b_idx, bc_618_ext),
+                        "1.618BC": (b_idx, c + bc_diff * 1.618),
                     }
                 )
 
@@ -2087,12 +2074,6 @@ def find_bearish_bat(
         x = pivots.loc[x_idx, "P"]
 
     if selected:
-        selected.update(
-            dict(
-                sym=sym,
-                pattern="BATD",
-                alt_name=alt_name
-            )
-        )
+        selected.update(dict(sym=sym, pattern="BATD", alt_name=alt_name))
 
     return selected

--- a/src/utils.py
+++ b/src/utils.py
@@ -1851,16 +1851,6 @@ def find_bullish_bat(
             )
         ):
 
-            if (
-                x == df.at[x_idx, "High"]
-                or a == df.at[a_idx, "Low"]
-                or b == df.at[b_idx, "High"]
-                or c == df.at[c_idx, "Low"]
-            ):
-                x_idx = pivots.loc[pivots.index[pos_after_x] :, "P"].idxmin()
-                x = pivots.loc[x_idx, "P"]
-                continue
-
             selected = dict(
                 df_start=df.index[0],
                 df_end=df.index[-1],

--- a/src/utils.py
+++ b/src/utils.py
@@ -1550,6 +1550,15 @@ def find_bullish_abcd(
         ab_diff = a - b
         c_retrace = bc_diff / ab_diff
 
+        if (
+            a == df.at[a_idx, "Low"]
+            or b == df.at[b_idx, "High"]
+            or c == df.at[c_idx, "Low"]
+        ):
+            # Check that the pattern is well formed
+            a, a_idx = c, c_idx
+            continue
+
         # Get the FIB ratio nearest to point C
         c_nearest_fib = fib_ser.loc[(fib_ser - c_retrace).abs().idxmin()]
 
@@ -1663,6 +1672,15 @@ def find_bearish_abcd(
         bc_diff = b - c
         ab_diff = b - a
         c_retrace = bc_diff / ab_diff
+
+        if (
+            a == df.at[a_idx, "High"]
+            or b == df.at[b_idx, "Low"]
+            or c == df.at[c_idx, "High"]
+        ):
+            # Check that the pattern is well formed
+            a, a_idx = c, c_idx
+            continue
 
         # Get the FIB ratio nearest to point C
         c_nearest_fib = fib_ser.loc[(fib_ser - c_retrace).abs().idxmin()]

--- a/src/utils.py
+++ b/src/utils.py
@@ -1743,7 +1743,7 @@ def find_bearish_abcd(
             terminal_point = max(ab_cd_ext, bc_ext)
 
         closes_above_terminal_point = (
-            df.loc[c_idx:, "Close"] < terminal_point
+            df.loc[c_idx:, "Close"] > terminal_point
         ).sum()
 
         if (

--- a/src/utils.py
+++ b/src/utils.py
@@ -1575,6 +1575,8 @@ def find_bullish_abcd(
         ):
 
             selected = dict(
+                df_start=df.index[0],
+                df_end=df.index[-1],
                 start=a_idx,
                 end=d_idx,
                 points={
@@ -1597,8 +1599,6 @@ def find_bullish_abcd(
             dict(
                 sym=sym,
                 pattern="BULL AB=CD",
-                df_start=df.index[0],
-                df_end=df.index[-1],
             )
         )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1559,8 +1559,10 @@ def find_bullish_abcd(
 
         ab_cd_ext = c - ab_diff
         bc_ext = c - bc_diff * c_fib_inverse
+        ab_27_ext = c - ab_diff * 1.27
+        ab_618_ext = c - ab_diff * 1.618
 
-        terminal_point = min(ab_cd_ext, bc_ext)
+        terminal_point = min(ab_27_ext, ab_618_ext)
 
         validation_threshold = terminal_point * 0.985
         lowest_close_after_b = df.loc[b_idx:, "Close"].min()
@@ -1591,6 +1593,10 @@ def find_bullish_abcd(
                     "AB=CD": (b_idx, ab_cd_ext),
                 },
             )
+
+            if lowest_close_after_b < min(ab_cd_ext, bc_ext):
+                selected["extra_points"]["1.27AB=CD"] = (b_idx, ab_27_ext)
+                selected["extra_points"]["1.618AB=CD"] = (b_idx, ab_618_ext)
 
         a, a_idx = c, c_idx
 
@@ -1665,9 +1671,11 @@ def find_bearish_abcd(
         c_fib_inverse = 1 / c_nearest_fib
 
         ab_cd_ext = c + ab_diff
-        bc_ext= c + bc_diff * c_fib_inverse
+        bc_ext = c + bc_diff * c_fib_inverse
+        ab_27_ext = c + ab_diff * 1.27
+        ab_618_ext = c + ab_diff * 1.618
 
-        terminal_point = max(ab_cd_ext, bc_ext)
+        terminal_point = max(ab_27_ext, ab_618_ext)
 
         validation_threshold = terminal_point * 1.015
         highest_close_after_b = df.loc[b_idx:, "Close"].max()
@@ -1698,6 +1706,10 @@ def find_bearish_abcd(
                     "AB=CD": (b_idx, ab_cd_ext),
                 },
             )
+
+            if highest_close_after_b > max(ab_cd_ext, bc_ext):
+                selected["extra_points"]["1.27AB=CD"] = (b_idx, ab_27_ext)
+                selected["extra_points"]["1.618AB=CD"] = (b_idx, ab_618_ext)
 
         a, a_idx = c, c_idx
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1900,19 +1900,42 @@ def find_bullish_bat(
 
         xa_886_retrace = a - xa_diff * 0.886
         bc_2_ext = c - bc_diff * 2
+        bc_618_ext = c - bc_diff * 1.618
         xa_13_ext = c - xa_diff * 1.13
 
+        ab_27_ext = c - ab_diff * 1.27
+
         lowest_close_after_b = df.loc[b_idx:, "Close"].min()
+        highest_high_after_c = df.loc[c_idx:, "High"].max()
+
+        if is_perfect_bat:
+            terminal_point = min(ab_27_ext, bc_2_ext)
+        elif is_alternate_bat:
+            values_dct = {
+                "2BC": bc_2_ext,
+                "2.618BC": c - bc_diff * 2.618,
+                "3BC": c - bc_diff * 3,
+                "3.618BC": c - bc_diff * 3.618,
+                "1.618AB=CD": c - ab_diff * 1.618,
+            }
+
+            closest_var = min(
+                values_dct, key=lambda k: abs(values_dct[k] - xa_13_ext)
+            )
+
+            terminal_point = min(xa_13_ext, values_dct[closest_var])
+        else:
+            terminal_point = min(xa_886_retrace, bc_618_ext)
+
+        closes_below_terminal_point = (
+            df.loc[c_idx:, "Close"] < terminal_point
+        ).sum()
 
         if (
-            d <= xa_886_retrace
+            d <= terminal_point
+            and closes_below_terminal_point < 7
             and d == lowest_close_after_b
-            and (
-                is_alternate_bat
-                and lowest_close_after_b > xa_13_ext * 0.985
-                or not is_alternate_bat
-                and lowest_close_after_b > x
-            )
+            and c == highest_high_after_c
         ):
 
             selected = dict(
@@ -1938,7 +1961,7 @@ def find_bullish_bat(
 
                 selected["extra_points"].update(
                     {
-                        "1.27AB=CD": (b_idx, c - ab_diff * 1.27),
+                        "1.27AB=CD": (b_idx, ab_27_ext),
                         "2BC": (b_idx, bc_2_ext),
                     }
                 )
@@ -1946,17 +1969,6 @@ def find_bullish_bat(
                 # Alternate BAT pattern
                 alt_name = "BULL Alternate BAT"
 
-                values_dct = {
-                    "2BC": bc_2_ext,
-                    "2.618BC": c - bc_diff * 2.618,
-                    "3BC": c - bc_diff * 3,
-                    "3.618BC": c - bc_diff * 3.618,
-                    "1.618AB=CD": c - ab_diff * 1.618,
-                }
-
-                closest_var = min(
-                    values_dct, key=lambda k: abs(values_dct[k] - xa_13_ext)
-                )
                 selected["extra_points"].update(
                     {
                         closest_var: (b_idx, values_dct[closest_var]),
@@ -1967,7 +1979,7 @@ def find_bullish_bat(
                 selected["extra_points"].update(
                     {
                         "0.886XA": (b_idx, xa_886_retrace),
-                        "1.618BC": (b_idx, c - bc_diff * 1.618),
+                        "1.618BC": (b_idx, bc_618_ext),
                     }
                 )
 
@@ -2065,23 +2077,48 @@ def find_bearish_bat(
         is_perfect_bat = b_retrace == 0.5 and (
             c_retrace == 0.5 or c_retrace == 0.618
         )
+
         is_alternate_bat = b_retrace == 0.382
 
         xa_886_retrace = a + xa_diff * 0.886
-        bc_2_ext = c + bc_diff * 2
         xa_13_ext = c + xa_diff * 1.13
 
+        bc_2_ext = c + bc_diff * 2
+        bc_618_ext = c + bc_diff * 1.618
+
+        ab_27_ext = c + ab_diff * 1.27
+
         highest_close_after_b = df.loc[b_idx:, "Close"].max()
+        lowest_low_after_c = df.loc[c_idx:, "Low"].min()
+        
+        if is_perfect_bat:
+            terminal_point = max(ab_27_ext, bc_2_ext)
+        elif is_alternate_bat:
+            values_dct = {
+                "2BC": bc_2_ext,
+                "2.618BC": c + bc_diff * 2.618,
+                "3BC": c + bc_diff * 3,
+                "3.618BC": c + bc_diff * 3.618,
+                "1.618AB=CD": c + ab_diff * 1.618,
+            }
+
+            closest_var = min(
+                values_dct, key=lambda k: abs(values_dct[k] - xa_13_ext)
+            )
+
+            terminal_point = max(xa_13_ext, values_dct[closest_var])
+        else:
+            terminal_point = max(xa_886_retrace, bc_618_ext)
+
+        closes_above_terminal_point = (
+            df.loc[c_idx:, "Close"] > terminal_point
+        ).sum()
 
         if (
-            d >= xa_886_retrace
+            d >= terminal_point 
+            and closes_above_terminal_point < 7
             and d == highest_close_after_b
-            and (
-                is_alternate_bat
-                and highest_close_after_b < xa_13_ext * 1.15
-                or not is_alternate_bat
-                and highest_close_after_b < x
-            )
+            and c == lowest_low_after_c
         ):
 
             selected = dict(
@@ -2107,25 +2144,13 @@ def find_bearish_bat(
 
                 selected["extra_points"].update(
                     {
-                        "1.27AB=CD": (b_idx, c + ab_diff * 1.27),
+                        "1.27AB=CD": (b_idx, ab_27_ext),
                         "2BC": (b_idx, bc_2_ext),
                     }
                 )
             elif is_alternate_bat:
                 # Alternate BAT pattern
                 alt_name = "Bear Alternate BAT"
-
-                values_dct = {
-                    "2BC": bc_2_ext,
-                    "2.618BC": c + bc_diff * 2.618,
-                    "3BC": c + bc_diff * 3,
-                    "3.618BC": c + bc_diff * 3.618,
-                    "1.618AB=CD": c + ab_diff * 1.618,
-                }
-
-                closest_var = min(
-                    values_dct, key=lambda k: abs(values_dct[k] - xa_13_ext)
-                )
 
                 selected["extra_points"].update(
                     {
@@ -2138,7 +2163,7 @@ def find_bearish_bat(
                 selected["extra_points"].update(
                     {
                         "0.886XA": (b_idx, xa_886_retrace),
-                        "1.618BC": (b_idx, c + bc_diff * 1.618),
+                        "1.618BC": (b_idx, bc_618_ext),
                     }
                 )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1557,10 +1557,10 @@ def find_bullish_abcd(
 
         c_fib_inverse = 1 / c_nearest_fib
 
-        bc_extension = c - ab_diff
-        bc_fib_extension = a - (ab_diff * c_fib_inverse)
+        ab_cd_ext = c - ab_diff
+        bc_ext = c - bc_diff * c_fib_inverse
 
-        terminal_point = min(bc_extension, bc_fib_extension)
+        terminal_point = min(ab_cd_ext, bc_ext)
 
         validation_threshold = terminal_point * 0.985
         lowest_close_after_b = df.loc[b_idx:, "Close"].min()
@@ -1593,8 +1593,8 @@ def find_bullish_abcd(
                 },
                 extra_points={
                     "direction": (c_idx, c),
-                    f"{c_fib_inverse:.3f}BC": (b_idx, bc_fib_extension),
-                    "AB=CD": (b_idx, bc_extension),
+                    f"{c_fib_inverse:.3f}BC": (b_idx, bc_ext),
+                    "AB=CD": (b_idx, ab_cd_ext),
                 },
             )
 
@@ -1672,10 +1672,10 @@ def find_bearish_abcd(
 
         c_fib_inverse = 1 / c_nearest_fib
 
-        bc_extension = c + ab_diff
-        bc_fib_extension = a + (ab_diff * c_fib_inverse)
+        ab_cd_ext = c + ab_diff
+        bc_ext= c + bc_diff * c_fib_inverse
 
-        terminal_point = max(bc_extension, bc_fib_extension)
+        terminal_point = max(ab_cd_ext, bc_ext)
 
         validation_threshold = terminal_point * 1.015
         highest_close_after_b = df.loc[b_idx:, "Close"].max()
@@ -1710,8 +1710,8 @@ def find_bearish_abcd(
                 },
                 extra_points={
                     "direction": (c_idx, c),
-                    f"{c_fib_inverse:.3f}BC": (b_idx, bc_fib_extension),
-                    "AB=CD": (b_idx, bc_extension),
+                    f"{c_fib_inverse:.3f}BC": (b_idx, bc_ext),
+                    "AB=CD": (b_idx, ab_cd_ext),
                 },
             )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1574,14 +1574,6 @@ def find_bullish_abcd(
             and c == highest_high_after_c
         ):
 
-            # termination_zone = abs(bc_extension - bc_fib_extension) / max(
-            #     bc_extension, bc_fib_extension
-            # )
-            #
-            # if termination_zone > 0.1:
-            #     a, a_idx = c, c_idx
-            #     continue
-
             selected = dict(
                 start=a_idx,
                 end=d_idx,
@@ -1688,14 +1680,6 @@ def find_bearish_abcd(
             and d == highest_close_after_b
             and c == lowest_low_after_c
         ):
-
-            # termination_zone = abs(bc_extension - bc_fib_extension) / min(
-            #     bc_extension, bc_fib_extension
-            # )
-            #
-            # if termination_zone > 0.1:
-            #     a, a_idx = c, c_idx
-            #     continue
 
             selected = dict(
                 df_start=df.index[0],

--- a/src/utils.py
+++ b/src/utils.py
@@ -1799,7 +1799,7 @@ def find_bullish_bat(
 
         xa_886_retrace = a - xa_diff * 0.886
 
-        bc_618_ext = a - ab_diff * 1.618
+        bc_618_ext = c - bc_diff * 1.618
         lowest_close_after_b = df.loc[b_idx:, "Close"].min()
 
         if d < b and lowest_close_after_b > x and d == lowest_close_after_b:
@@ -1829,7 +1829,7 @@ def find_bullish_bat(
                 extra_points={
                     "direction": (c_idx, c),
                     "0.886XA": (b_idx, xa_886_retrace),
-                    "1.618AB=CD": (b_idx, bc_618_ext),
+                    "1.618BC": (b_idx, bc_618_ext),
                 },
             )
 
@@ -1918,7 +1918,7 @@ def find_bearish_bat(
 
         xa_886_retrace = a + xa_diff * 0.886
 
-        bc_618_ext = a + ab_diff * 1.618
+        bc_618_ext = c + bc_diff * 1.618
         highest_close_after_b = df.loc[b_idx:, "Close"].max()
 
         if d > b and highest_close_after_b < x and d == highest_close_after_b:
@@ -1948,7 +1948,7 @@ def find_bearish_bat(
                 extra_points={
                     "direction": (c_idx, c),
                     "0.886XA": (b_idx, xa_886_retrace),
-                    "AB=CD": (b_idx, bc_618_ext),
+                    "1.618BC": (b_idx, bc_618_ext),
                 },
             )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1717,7 +1717,7 @@ def find_bearish_abcd(
         selected.update(
             dict(
                 sym=sym,
-                pattern="BULL AB=CD",
+                pattern="BEAR AB=CD",
             )
         )
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1877,10 +1877,20 @@ def find_bullish_bat(
                 # Alternate BAT pattern
                 alt_name = "BULL Alternate BAT"
 
+                values_dct = {
+                    "2BC": bc_2_ext,
+                    "2.618BC": c - bc_diff * 2.618,
+                    "3BC": c - bc_diff * 3,
+                    "3.618BC": c - bc_diff * 3.618,
+                    "1.618AB=CD": c - ab_diff * 1.618,
+                }
+
+                closest_var = min(
+                    values_dct, key=lambda k: abs(values_dct[k] - xa_13_ext)
+                )
                 selected["extra_points"].update(
                     {
-                        "2BC": (b_idx, bc_2_ext),
-                        "1.618AB=CD": (b_idx, ab_618_ext),
+                        closest_var: (b_idx, values_dct[closest_var]),
                         "1.13XA": (b_idx, xa_13_ext),
                     }
                 )
@@ -2046,10 +2056,21 @@ def find_bearish_bat(
                 # Alternate BAT pattern
                 alt_name = "Bear Alternate BAT"
 
+                values_dct = {
+                    "2BC": bc_2_ext,
+                    "2.618BC": c + bc_diff * 2.618,
+                    "3BC": c + bc_diff * 3,
+                    "3.618BC": c + bc_diff * 3.618,
+                    "1.618AB=CD": c + ab_diff * 1.618,
+                }
+
+                closest_var = min(
+                    values_dct, key=lambda k: abs(values_dct[k] - xa_13_ext)
+                )
+
                 selected["extra_points"].update(
                     {
-                        "2BC": (b_idx, bc_2_ext),
-                        "1.618AB=CD": (b_idx, ab_618_ext),
+                        closest_var: (b_idx, values_dct[closest_var]),
                         "1.13XA": (b_idx, xa_13_ext),
                     }
                 )

--- a/src/utils.py
+++ b/src/utils.py
@@ -931,7 +931,8 @@ def find_triangles(
 
             return dict(
                 sym=sym,
-                pattern=triangle,
+                pattern="TRNG",
+                alt_name=triangle,
                 start=a_idx,
                 end=f_idx,
                 df_start=df.index[0],
@@ -1605,7 +1606,8 @@ def find_bullish_abcd(
         selected.update(
             dict(
                 sym=sym,
-                pattern="BULL AB=CD",
+                pattern="ABCDU",
+                alt_name="BULL AB=CD",
             )
         )
 
@@ -1718,7 +1720,8 @@ def find_bearish_abcd(
         selected.update(
             dict(
                 sym=sym,
-                pattern="BEAR AB=CD",
+                pattern="ABCDD",
+                alt_name="BEAR AB=CD",
             )
         )
 
@@ -1732,6 +1735,7 @@ def find_bullish_bat(
     Bullish Bat harmonic pattern
     """
     is_perfect_bat = is_alternate_bat = False
+    alt_name = "Bull BAT"
     pivot_len = pivots.shape[0]
 
     x_idx = pivots["P"].idxmin()
@@ -1861,6 +1865,8 @@ def find_bullish_bat(
 
             if is_perfect_bat:
                 # Perfect BAT pattern
+                alt_name = "Bull Perfect BAT"
+
                 selected["extra_points"].update(
                     {
                         "1.27AB=CD": (b_idx, ab_27_ext),
@@ -1869,6 +1875,8 @@ def find_bullish_bat(
                 )
             elif is_alternate_bat:
                 # Alternate BAT pattern
+                alt_name = "BULL Alternate BAT"
+
                 selected["extra_points"].update(
                     {
                         "2BC": (b_idx, bc_2_ext),
@@ -1892,6 +1900,7 @@ def find_bullish_bat(
             dict(
                 sym=sym,
                 pattern="BATU",
+                alt_name=alt_name
             )
         )
 
@@ -1905,6 +1914,7 @@ def find_bearish_bat(
     Bearish Bat harmonic pattern
     """
     is_perfect_bat = is_alternate_bat = False
+    alt_name = "Bear BAT"
     pivot_len = pivots.shape[0]
 
     x_idx = pivots["P"].idxmax()
@@ -2024,6 +2034,8 @@ def find_bearish_bat(
 
             if is_perfect_bat:
                 # Perfect BAT pattern
+                alt_name = "Bear Perfect BAT"
+
                 selected["extra_points"].update(
                     {
                         "1.27AB=CD": (b_idx, ab_27_ext),
@@ -2032,6 +2044,8 @@ def find_bearish_bat(
                 )
             elif is_alternate_bat:
                 # Alternate BAT pattern
+                alt_name = "Bear Alternate BAT"
+
                 selected["extra_points"].update(
                     {
                         "2BC": (b_idx, bc_2_ext),
@@ -2056,6 +2070,7 @@ def find_bearish_bat(
             dict(
                 sym=sym,
                 pattern="BATD",
+                alt_name=alt_name
             )
         )
 


### PR DESCRIPTION
## Highlights v4.0.3
Added new harmonic patterns - Gartley and Crab
Added support to variations of harmonic patterns - Perfect and Alternate versions
Revamped the user interface with a selection menu with support for keyboard and shortcuts
More precise reversal zones for harmonic patterns. Reversal lines also display the price in the label.

5b90ee6 (HEAD -> dev, tag: v4.0.3, origin/dev) Bump to version 4.0.3

1e53b8c Add support for Crab and Gartley patterns in backtest.py

8597940 Revamped user interface using questionary package

2ac859f Added Crab harmonic pattern

9a7326d Added Gartley Harmonic pattern

1bfe04d Minor corrections

f953490  

- Added code to distinguish Perfect, Alternate, and normal BAT pattern.  
- Filter BAT pattern based on number of closes below terminal point.

05cb72c Fix condition for closes above terminal point in Bearish AB=CD

f30c008 

- Added code to distinguish Perfect, Alternate, and normal AB=CD pattern. 
- Filter AB=CD based on number of closes below terminal point.

ddaafb0 Use nearest FIB ratio for C point in AB=CD for pattern detection.

5088d31 Remove duplicate if check in utils.py:find_bullish_bat

85f5fd1 Add checks to ensure AB=CD is well formed

9310af8 

- Fix: Reversal lines plotted from Point C on chart. 
- Add price level to reversal line labels.

d85670d Remove unnecessary variables in BAT pattern function

126a680 For Alternate BAT, only add 1.13XA and the next closest reversal line

63e7c31 

- Add alternate names for some patterns in return dict. 
- Use alternate name in Plot title where available in Plotter.py.

21b7aa5 Added uncaught exception handler to backtest.py

8a3e4ac 

- Added support for Alternate BAT and Perfect BAT pattern. 
-  Plot reversal lines based on type of BAT pattern.
- Fix: Added checks to ensure pattern is well formed.

670c1b2 Fix: Correct incorrect pattern name returned in `utils.py:find_bearish_abcd`

2413e3b 

- Added alternate 1.27AB=CD and 1.618AB=CD projection lines. 
- Only add alternate lines when close below initial reversal lines.

eab07ae Moved df_start and df_end within while loop in utils.py:find_bull_abcd

66f0634 Filter out BAT patterns if close is above 1.618 BC extension.

c14bfd6 Removed some commented code no longer required

e869ad4 Fixed Fib extension calculation in BAT pattern.

09461fe Corrected Fib extension calculation in AB=CD pattern
