### PR TITLE
Dev v4.0.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 fast_csv_loader>=1.0.1
 mplfinance==0.12.10b0
-pandas==2.2.2
+pandas==2.0.3
 questionary==2.0.1
 tqdm==4.66.5

--- a/src/Plotter.py
+++ b/src/Plotter.py
@@ -25,6 +25,25 @@ except AttributeError:
 
     pairwise_fn = pairwise
 
+try:
+    batched_fn = itertools.batched
+except AttributeError:
+    # Support for batched function for Python 3.12 and lower
+    # Source https://docs.python.org/3/library/itertools.html#itertools.batched
+    def batched(iterable, n, *, strict=False):
+        """
+        batched('ABCDEFG', 3) → ABC DEF G
+        """
+        if n < 1:
+            raise ValueError("n must be at least one")
+        it = iter(iterable)
+        while batch := tuple(itertools.islice(it, n)):
+            if strict and len(batch) != n:
+                raise ValueError("batched(): incomplete batch")
+            yield batch
+
+    batched_fn = batched
+
 
 class Plotter:
     idx = 0
@@ -241,7 +260,7 @@ class Plotter:
         if pattern in ("Symmetric", "Ascending", "Descending", "DNTL", "UPTL"):
             points = dct["extra_points"]
 
-            return tuple(line for line in itertools.batched(points.values(), 2))
+            return tuple(line for line in batched_fn(points.values(), 2))
 
         points = dct["points"]
         return tuple(line for line in pairwise_fn(points.values()))

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -70,8 +70,8 @@ def parse_cli_args():
         "abcdd",
         "batu",
         "batd",
-        "garu",
-        "gard",
+        "gartu",
+        "gartd",
         "crabu",
         "crabd",
     )
@@ -194,8 +194,8 @@ def scan(
         "abcdd": utils.find_bearish_abcd,
         "batu": utils.find_bullish_bat,
         "batd": utils.find_bearish_bat,
-        "garu": utils.find_bullish_gartley,
-        "gard": utils.find_bearish_gartley,
+        "gartu": utils.find_bullish_gartley,
+        "gartd": utils.find_bearish_gartley,
         "crabu": utils.find_bullish_crab,
         "crabd": utils.find_bearish_crab,
     }

--- a/src/init.py
+++ b/src/init.py
@@ -33,11 +33,17 @@ def uncaught_exception_handler(*args):
 def get_user_selection() -> Optional[str]:
     while True:
         ptn_key = questionary.select(
-            message="Select an option [ ** Excludes Trendlines & Triangles ]",
+            message="Select an option [ ** Excludes Trendlines & Triangles & Harmonics ]",
             choices=[
-                questionary.Choice("[ALL] Scan All", value="all"),
+                questionary.Choice("[ALL] Scan All **", value="all"),
                 questionary.Choice("[BULL] Scan only Bull **", value="bull"),
                 questionary.Choice("[BEAR] Scan only Bear **", value="bear"),
+                questionary.Choice(
+                    "[BULL_HARM] All BULL Harmonic pattern", value="bull_harm"
+                ),
+                questionary.Choice(
+                    "[BEAR_HARM] All BEAR Harmonic pattern", value="bear_harm"
+                ),
                 questionary.Choice(
                     "[TRNG] Triangles (Symetrical, Ascending, Descending)",
                     value="trng",
@@ -412,7 +418,8 @@ if __name__ == "__main__":
         "--pattern",
         type=str,
         metavar="str",
-        choices=tuple(fn_dict.keys()) + ("all", "bull", "bear"),
+        choices=tuple(fn_dict.keys())
+        + ("all", "bull", "bear", "bull_harm", "bear_harm"),
         help=f"String pattern. One of {', '.join(fn_dict.keys())}",
     )
 
@@ -597,15 +604,25 @@ if __name__ == "__main__":
     if key in fn_dict:
         fns = (fn_dict[key],)
     elif key == "bull":
-        bull_list = ("vcpu", "hnsu", "dbot", "abcdu", "batu", "crabu", "gartu")
+        bull_list = ("vcpu", "hnsu", "dbot")
 
         fns = tuple(v for k, v in fn_dict.items() if k in bull_list)
     elif key == "bear":
-        bear_list = ("vcpd", "hnsd", "dtop", "abcdd", "batd", "crabd", "gartd")
+        bear_list = ("vcpd", "hnsd", "dtop")
+
+        fns = tuple(v for k, v in fn_dict.items() if k in bear_list)
+    elif key == "bull_harm":
+        bull_list = ("abcdu", "batu", "gartu", "crabu")
+
+        fns = tuple(v for k, v in fn_dict.items() if k in bull_list)
+    elif key == "bear_harm":
+        bear_list = ("abcdd", "batd", "gartd", "crabd")
 
         fns = tuple(v for k, v in fn_dict.items() if k in bear_list)
     else:
-        fns = tuple(v for k, v in fn_dict.items() if k in list(fn_dict.keys()))
+        fns = tuple(
+            fn_dict[k] for k in ("vcpu", "hnsu", "dbot", "vcpd", "hnsd", "dtop")
+        )
 
     try:
         patterns = process(data, key, fns, futures)

--- a/src/init.py
+++ b/src/init.py
@@ -348,7 +348,7 @@ def process(
 # Differentiate between the main thread and child threads on Windows
 # see https://stackoverflow.com/a/57811249
 if __name__ == "__main__":
-    version = "4.0.5"
+    version = "4.0.6"
 
     futures: List[concurrent.futures.Future] = []
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1614,7 +1614,9 @@ def find_bullish_abcd(
             terminal_point = min(ab_27_ext, ab_618_ext)
 
         lows_after_c = df.loc[c_idx:, "Low"]
-        lows_below_terminal_point = lows_after_c[lows_after_c < terminal_point]
+        lows_below_terminal_point = lows_after_c.loc[
+            lows_after_c < terminal_point
+        ]
 
         if lows_below_terminal_point.empty:
             has_tested = False
@@ -1794,9 +1796,9 @@ def find_bearish_abcd(
         ).sum()
 
         if (
-            d > b + (terminal_point - b) * 0.5
-            and closes_above_terminal_point < 7
+            closes_above_terminal_point < 7
             and c == lowest_low_after_c
+            and d > b + (terminal_point - b) * 0.5
             and (
                 has_tested
                 and (df.index[-1] - highs_above_terminal_point.index[0]).days

--- a/src/utils.py
+++ b/src/utils.py
@@ -32,7 +32,7 @@ ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 fib_ser = pd.Series((0.236, 0.382, 0.5, 0.618, 0.707, 0.786, 0.886, 1))
 
 
-def find_relative_clusters(levels, reference_key) -> dict:
+def get_relative_clusters(levels, reference_key) -> dict:
     """
     Find price levels relatively close to the price associated with the reference key.
 
@@ -1966,7 +1966,7 @@ def find_bullish_bat(
         if is_perfect_bat:
             terminal_point = min(ab_27_ext, bc_2_ext, xa_886_retrace)
         elif is_alternate_bat:
-            clustered_levels = find_relative_clusters(
+            clustered_levels = get_relative_clusters(
                 {
                     "1.13XA": xa_13_ext,
                     "2BC": bc_2_ext,
@@ -1984,7 +1984,7 @@ def find_bullish_bat(
 
             terminal_point = clustered_levels[lowest_var]
         else:
-            clustered_levels = find_relative_clusters(
+            clustered_levels = get_relative_clusters(
                 {
                     "0.886XA": xa_886_retrace,
                     "1.618BC": bc_618_ext,
@@ -2185,7 +2185,7 @@ def find_bearish_bat(
         if is_perfect_bat:
             terminal_point = max(ab_27_ext, bc_2_ext, xa_886_retrace)
         elif is_alternate_bat:
-            clustered_levels = find_relative_clusters(
+            clustered_levels = get_relative_clusters(
                 {
                     "1.13XA": xa_13_ext,
                     "1.618AB=CD": c + ab_diff * 1.618,
@@ -2201,7 +2201,7 @@ def find_bearish_bat(
 
             terminal_point = clustered_levels[max_var]
         else:
-            clustered_levels = find_relative_clusters(
+            clustered_levels = get_relative_clusters(
                 {
                     "0.886XA": xa_886_retrace,
                     "1.618BC": bc_618_ext,
@@ -2441,7 +2441,7 @@ def find_bullish_gartley(
                 # Perfect Gartley pattern
                 alt_name = "Bull Perfect Gartley"
 
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "AB=CD": ab_cd_ext,
                         "0.786XA": xa_786_retrace,
@@ -2458,7 +2458,7 @@ def find_bullish_gartley(
                     }
                 )
             else:
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "AB=CD": ab_cd_ext,
                         "0.786XA": xa_786_retrace,
@@ -2627,7 +2627,7 @@ def find_bearish_gartley(
                 # Perfect Gartley pattern
                 alt_name = "Bear Perfect Gartley"
 
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "AB=CD": ab_cd_ext,
                         "0.786XA": xa_786_retrace,
@@ -2644,7 +2644,7 @@ def find_bearish_gartley(
                     }
                 )
             else:
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "AB=CD": ab_cd_ext,
                         "0.786XA": xa_786_retrace,
@@ -2813,7 +2813,7 @@ def find_bullish_crab(
                 # Perfect crab pattern
                 alt_name = "Bull Perfect Crab"
 
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "3.14BC": bc_3_14_ext,
                         "1.618XA": xa_618_ext,
@@ -2833,7 +2833,7 @@ def find_bullish_crab(
                 # Deep Crab pattern
                 alt_name = "Bull Deep Crab"
 
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "1.618XA": xa_618_ext,
                         "1.27AB": ab_27_ext,
@@ -2850,7 +2850,7 @@ def find_bullish_crab(
                     }
                 )
             else:
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "1.618XA": xa_618_ext,
                         "2.618BC": c - bc_diff * 2.618,
@@ -3023,7 +3023,7 @@ def find_bearish_crab(
                 # Perfect crab pattern
                 alt_name = "Bear Perfect Crab"
 
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "3.14BC": bc_3_14_ext,
                         "1.618XA": xa_618_ext,
@@ -3043,7 +3043,7 @@ def find_bearish_crab(
                 # Deep Crab pattern
                 alt_name = "Bear Deep Crab"
 
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "1.618XA": xa_618_ext,
                         "1.27AB": ab_27_ext,
@@ -3060,7 +3060,7 @@ def find_bearish_crab(
                     }
                 )
             else:
-                clustered_levels = find_relative_clusters(
+                clustered_levels = get_relative_clusters(
                     {
                         "1.618XA": xa_618_ext,
                         "2.618BC": c + bc_diff * 2.618,

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,7 +29,7 @@ is_silent = None
 
 ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
-fib_ser = pd.Series((0.382, 0.5, 0.618, 0.707, 0.786, 0.886))
+fib_ser = pd.Series((0.236, 0.382, 0.5, 0.618, 0.707, 0.786, 0.886, 1))
 
 
 def getY(slope, yintercept, x_value) -> float:

--- a/src/utils.py
+++ b/src/utils.py
@@ -32,6 +32,32 @@ ascii_upper = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 fib_ser = pd.Series((0.236, 0.382, 0.5, 0.618, 0.707, 0.786, 0.886, 1))
 
 
+def find_relative_clusters(levels, reference_key) -> dict:
+    """
+    Find price levels relatively close to the price associated with the reference key.
+
+    Parameters:
+        price_levels (dict): A dictionary of price levels with keys as level names and values as prices (float).
+        reference_key (str): The key in the dictionary to use as the reference point.
+    """
+    reference_price = levels[reference_key]
+
+    mean_dev = np.mean(
+        tuple(
+            abs(price - reference_price)
+            for price in levels.values()
+            if price != reference_price
+        )
+    )
+
+    # Find price levels that fall within the mean deviation range
+    return {
+        level: price
+        for level, price in levels.items()
+        if abs(price - reference_price) <= mean_dev
+    }
+
+
 def getY(slope, yintercept, x_value) -> float:
     """
     Returns the value of the Y-axis (Price) at the given X-axis value


### PR DESCRIPTION
Changelog v4.0.6

f14e675 (HEAD -> dev) Bump to version 4.0.6

1a4f00b Add compatibility for itertools.batched in python 3.11 and lower

86b392e Downgraded pandas to 2.0.3 for Python 3.8 compatibility

0a147dd

- Add scan options for bull and bear harmonic patterns to interactive menu.
- Added `bull_harm` and `bear_harm` to CLI scan options for harmonic patterns.
- Harmonic patterns no longer included in `bull`, `bear` and `all` scan options.
- Uptrend and downtrend scan no longer included in `all` scan option.

403f8a7 Rename find_relative_clusters to get_relative_clusters

    Avoid confusion with find_* patterns functions

4f49278 Minor code formatting

b7462b5 Added improvements to Crab pattern detection

    - More precise retracements filters for Crab pattern
    - Only plot reversals lines which are clustered close to 1.618 XA line.
    - Set 1.618 XA as the terminal point for the pattern.
    - Last close must be halfway between B and the terminal point.
    - Check if price tested the terminal point and less than 7 days have passed.

46e0af1 Added improvements to Gartley pattern detection

    - Only plot reversals lines which are clustered close to 0.886 XA line.
    - Skip patterns if X point is violated on a closing basis.
    - Set 0.786 XA as the terminal point for the pattern.
    - Last close must be below B.
    - Check if price tested the terminal point and less than 7 days have passed.

f6cd16a Added improvements to BAT pattern detection

    - Only plot reversals lines which are clustered close to 0.886 XA line.
    - Added 0.886 XA line to terminal point calculation in Perfect BAT
    - Last close must be atleast half way between b and the terminal point
    - Check if price tested the terminal point and less than 7 days have passed.

77a1e7a Added filters to AB=CD pattern detection

    - Last close must be atleast half way between b and the terminal point
    - Check if price tested the terminal point and less than 7 days have
      passed.

ef68d75 Added find_relative_clusters function to utils.py

    Finds price levels that are relatively close to the reference price.

54ff376 Extend the fib_series range to more accurately get the nearest fib ratio.

    Previously, the nearest fib ratio was always capped at 0.382 and 0.886.
    For example, a 1 retracement will still show as 0.886. Added 1 and 0.236 to
    get a more accurate nearest fib ratio. This change allows patterns to be more
    accurately filtered.

901710f Fix: Misspelled Gartley CLI option in backtest.py. Now GARTU or GARTD.