### PR TITLE
Dev v4.0.7

### DIFF
--- a/src/Plotter.py
+++ b/src/Plotter.py
@@ -382,7 +382,7 @@ class Plotter:
 
                 # If labels are too close, adjust the label positions
                 if diff <= self.threshold:
-                    if prev_diff is None or prev_diff > self.threshold:
+                    if prev_diff and prev_diff <= self.threshold:
                         y_offset = -30
 
                 prev_diff = diff

--- a/src/Plotter.py
+++ b/src/Plotter.py
@@ -382,6 +382,10 @@ class Plotter:
 
                 # If labels are too close, adjust the label positions
                 if diff <= self.threshold:
+                    if self.mode == "expand":
+                        y_offset = -50
+                        x_offset = -40
+
                     if prev_diff and prev_diff <= self.threshold:
                         y_offset = -30
 

--- a/src/backtest.py
+++ b/src/backtest.py
@@ -74,6 +74,8 @@ def parse_cli_args():
         "gartd",
         "crabu",
         "crabd",
+        "bflyu",
+        "bflyd",
     )
 
     parser = argparse.ArgumentParser(description="Run backdated pattern scan")
@@ -198,6 +200,8 @@ def scan(
         "gartd": utils.find_bearish_gartley,
         "crabu": utils.find_bullish_crab,
         "crabd": utils.find_bearish_crab,
+        "bflyu": utils.find_bullish_butterfly,
+        "bflyd": utils.find_bearish_butterfly,
     }
 
     df = loader.get(sym)

--- a/src/init.py
+++ b/src/init.py
@@ -653,7 +653,7 @@ if __name__ == "__main__":
         f"Got {count - 1} patterns for `{key}`.\n\nRun `py init.py --plot {fname}` to view results."
     )
 
-    if config.get("POST_SCAN_PLOT", True):
+    if config.get("POST_SCAN_PLOT", True) and not args.save:
         # last item in patterns is the meta data like timeframe, end_date etc
         # Pop it out as we don't require it here
         patterns.pop()

--- a/src/init.py
+++ b/src/init.py
@@ -71,6 +71,9 @@ def get_user_selection() -> Optional[str]:
                         "[GARTU] Gartley Harmonic", value="gartu"
                     ),
                     questionary.Choice("[CRABU] Crab Harmonic", value="crabu"),
+                    questionary.Choice(
+                        "[BFLYU] Butterfly Harmonic", value="bflyu"
+                    ),
                     questionary.Choice("Back to main", value="MAIN"),
                 ],
                 use_shortcuts=True,
@@ -90,6 +93,9 @@ def get_user_selection() -> Optional[str]:
                         "[GARTD] Gartley Harmonic", value="gartd"
                     ),
                     questionary.Choice("[CRABD] Crab Harmonic", value="crabd"),
+                    questionary.Choice(
+                        "[BFLYD] Butterfly Harmonic", value="bflyd"
+                    ),
                     questionary.Choice("Back to main", value="MAIN"),
                 ],
                 use_shortcuts=True,
@@ -382,6 +388,8 @@ if __name__ == "__main__":
         "gartd": utils.find_bearish_gartley,
         "crabu": utils.find_bullish_crab,
         "crabd": utils.find_bearish_crab,
+        "bflyu": utils.find_bullish_butterfly,
+        "bflyd": utils.find_bearish_butterfly,
     }
 
     # Parse CLI arguments
@@ -612,11 +620,11 @@ if __name__ == "__main__":
 
         fns = tuple(v for k, v in fn_dict.items() if k in bear_list)
     elif key == "bull_harm":
-        bull_list = ("abcdu", "batu", "gartu", "crabu")
+        bull_list = ("abcdu", "batu", "gartu", "crabu", "bflyu")
 
         fns = tuple(v for k, v in fn_dict.items() if k in bull_list)
     elif key == "bear_harm":
-        bear_list = ("abcdd", "batd", "gartd", "crabd")
+        bear_list = ("abcdd", "batd", "gartd", "crabd", "bflyd")
 
         fns = tuple(v for k, v in fn_dict.items() if k in bear_list)
     else:

--- a/src/init.py
+++ b/src/init.py
@@ -354,7 +354,7 @@ def process(
 # Differentiate between the main thread and child threads on Windows
 # see https://stackoverflow.com/a/57811249
 if __name__ == "__main__":
-    version = "4.0.6"
+    version = "4.0.7"
 
     futures: List[concurrent.futures.Future] = []
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1633,13 +1633,16 @@ def find_bullish_abcd(
             df.loc[c_idx:, "Close"] < terminal_point
         ).sum()
 
+        ab_completion = (b_idx - a_idx).days
+        cd_completion = (d_idx - c_idx).days
+
         if (
             d < b - (b - terminal_point) * 0.5
+            and cd_completion < ab_completion * 2
             and closes_below_terminal_point < 7
-            and c == highest_high_after_c
             and (
                 has_tested
-                and (df.index[-1] - lows_below_terminal_point.index[0]).days < 7
+                and (d_idx - lows_below_terminal_point.index[0]).days < 7
                 or not has_tested
             )
         ):
@@ -1805,14 +1808,16 @@ def find_bearish_abcd(
             df.loc[c_idx:, "Close"] > terminal_point
         ).sum()
 
+        ab_completion = (b_idx - a_idx).days
+        cd_completion = (d_idx - c_idx).days
+
         if (
             closes_above_terminal_point < 7
-            and c == lowest_low_after_c
+            and cd_completion < ab_completion * 2
             and d > b + (terminal_point - b) * 0.5
             and (
                 has_tested
-                and (df.index[-1] - highs_above_terminal_point.index[0]).days
-                < 7
+                and (d_idx - highs_above_terminal_point.index[0]).days < 7
                 or not has_tested
             )
         ):

--- a/src/utils.py
+++ b/src/utils.py
@@ -1605,20 +1605,21 @@ def find_bullish_abcd(
         ab_27_ext = c - ab_diff * 1.27
         ab_618_ext = c - ab_diff * 1.618
 
-        lowest_close_after_c = df.loc[c_idx:, "Close"].min()
-        highest_high_after_c = df.loc[c_idx:, "High"].max()
+        lowest_close_from_c = df.loc[c_idx:, "Close"].min()
 
         is_perfect = c_retrace == 0.618 and ab_cd_ext <= bc_618_ext
-        is_alternate = lowest_close_after_c < max(ab_27_ext, ab_618_ext)
+
+        is_alternate = lowest_close_from_c < ab_cd_ext
 
         terminal_point = ab_cd_ext
 
         if is_perfect:
             terminal_point = ab_cd_ext
         elif is_alternate:
-            terminal_point = min(ab_27_ext, ab_618_ext)
+            terminal_point = ab_618_ext
 
         lows_after_c = df.loc[c_idx:, "Low"]
+
         lows_below_terminal_point = lows_after_c.loc[
             lows_after_c < terminal_point
         ]
@@ -1778,17 +1779,16 @@ def find_bearish_abcd(
         ab_618_ext = c + ab_diff * 1.618
 
         highest_close_after_c = df.loc[c_idx:, "Close"].max()
-        lowest_low_after_c = df.loc[c_idx:, "Low"].min()
 
         is_perfect = c_retrace == 0.618 and ab_cd_ext >= bc_618_ext
-        is_alternate = highest_close_after_c > min(ab_27_ext, ab_618_ext)
+        is_alternate = highest_close_after_c > ab_cd_ext
 
         terminal_point = ab_cd_ext
 
         if is_perfect:
             terminal_point = ab_cd_ext
         elif is_alternate:
-            terminal_point = max(ab_27_ext, ab_618_ext)
+            terminal_point = ab_618_ext
 
         highs_after_c = df.loc[c_idx:, "High"]
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -1671,16 +1671,17 @@ def find_bullish_abcd(
                         "1.618BC": (b_idx, bc_618_ext),
                     }
                 )
-            elif is_alternate:
-                alt_name = "Bull Alternate AB=CD"
-
-                selected["extra_points"].update(
-                    {
-                        "1.27AB=CD": (b_idx, ab_27_ext),
-                        "1.618AB=CD": (b_idx, ab_618_ext),
-                    }
-                )
             else:
+                if is_alternate:
+                    alt_name = "Bull Alternate AB=CD"
+
+                    selected["extra_points"].update(
+                        {
+                            "1.27AB=CD": (b_idx, ab_27_ext),
+                            "1.618AB=CD": (b_idx, ab_618_ext),
+                        }
+                    )
+
                 selected["extra_points"].update(
                     {
                         f"{c_fib_inverse:.3f}BC": (b_idx, bc_ext),
@@ -1846,16 +1847,17 @@ def find_bearish_abcd(
                         "1.618BC": (b_idx, bc_618_ext),
                     }
                 )
-            elif is_alternate:
-                alt_name = "Bear Alternate AB=CD"
-
-                selected["extra_points"].update(
-                    {
-                        "1.27AB=CD": (b_idx, ab_27_ext),
-                        "1.618AB=CD": (b_idx, ab_618_ext),
-                    }
-                )
             else:
+                if is_alternate:
+                    alt_name = "Bear Alternate AB=CD"
+
+                    selected["extra_points"].update(
+                        {
+                            "1.27AB=CD": (b_idx, ab_27_ext),
+                            "1.618AB=CD": (b_idx, ab_618_ext),
+                        }
+                    )
+
                 selected["extra_points"].update(
                     {
                         f"{c_fib_inverse:.3f}BC": (b_idx, bc_ext),

--- a/src/utils.py
+++ b/src/utils.py
@@ -1973,7 +1973,7 @@ def find_bullish_bat(
         clustered_levels = {}
 
         xa_886_retrace = a - xa_diff * 0.886
-        xa_13_ext = c - xa_diff * 1.13
+        xa_13_ext = a - xa_diff * 1.13
 
         bc_2_ext = c - bc_diff * 2
         bc_618_ext = c - bc_diff * 1.618
@@ -2199,7 +2199,7 @@ def find_bearish_bat(
         clustered_levels = {}
 
         xa_886_retrace = a + xa_diff * 0.886
-        xa_13_ext = c + xa_diff * 1.13
+        xa_13_ext = a + xa_diff * 1.13
 
         bc_2_ext = c + bc_diff * 2
         bc_618_ext = c + bc_diff * 1.618
@@ -2809,8 +2809,8 @@ def find_bullish_crab(
         xa_618_ext = a - xa_diff * 1.618
 
         bc_3_14_ext = c - bc_diff * 3.14
-        ab_618_ext = a - ab_diff * 1.618
-        ab_27_ext = a - ab_diff * 1.27
+        ab_618_ext = c - ab_diff * 1.618
+        ab_27_ext = c - ab_diff * 1.27
 
         terminal_point = xa_618_ext
 
@@ -3023,9 +3023,8 @@ def find_bearish_crab(
         xa_618_ext = a + xa_diff * 1.618
 
         bc_3_14_ext = c + bc_diff * 3.14
-
-        ab_618_ext = a + ab_diff * 1.618
-        ab_27_ext = a + ab_diff * 1.27
+        ab_618_ext = c + ab_diff * 1.618
+        ab_27_ext = c + ab_diff * 1.27
 
         terminal_point = xa_618_ext
 
@@ -3229,7 +3228,7 @@ def find_bullish_butterfly(
             continue
 
         xa_27_ext = a - xa_diff * 1.27
-        ab_27_ext = a - ab_diff * 1.27
+        ab_27_ext = c - ab_diff * 1.27
 
         bc_618_ext = c - bc_diff * 1.618
 
@@ -3412,7 +3411,7 @@ def find_bearish_butterfly(
             continue
 
         xa_27_ext = a + xa_diff * 1.27
-        ab_27_ext = a + ab_diff * 1.27
+        ab_27_ext = c + ab_diff * 1.27
 
         bc_618_ext = c + bc_diff * 1.618
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -2846,6 +2846,12 @@ def find_bullish_crab(
                         "1.618XA": xa_618_ext,
                         "1.27AB": ab_27_ext,
                         "1.618AB": ab_618_ext,
+                        "2.24BC": c - bc_diff * 2.24,
+                        "2.618BC": c - bc_diff * 2.618,
+                        "3.14BC": c - bc_diff * 3.14,
+                        "3.618BC": c - bc_diff * 3.618,
+                        "1.27AB": ab_27_ext,
+                        "1.618AB": ab_618_ext,
                     },
                     "1.618XA",
                 )
@@ -2854,7 +2860,7 @@ def find_bullish_crab(
                     {
                         level: (b_idx, price)
                         for level, price in clustered_levels.items()
-                        if price < x
+                        if price < x and price >= xa_618_ext
                     }
                 )
             else:
@@ -2864,6 +2870,8 @@ def find_bullish_crab(
                         "2.618BC": c - bc_diff * 2.618,
                         "3.14BC": c - bc_diff * 3.14,
                         "3.618BC": c - bc_diff * 3.618,
+                        "1.27AB": ab_27_ext,
+                        "1.618AB": ab_618_ext,
                     },
                     "1.618XA",
                 )
@@ -3037,6 +3045,8 @@ def find_bearish_crab(
                         "3.14BC": bc_3_14_ext,
                         "1.618XA": xa_618_ext,
                         "1.618AB": ab_618_ext,
+                        "1.27AB": ab_27_ext,
+                        "1.618AB": ab_618_ext,
                     },
                     "1.618XA",
                 )
@@ -3057,6 +3067,10 @@ def find_bearish_crab(
                         "1.618XA": xa_618_ext,
                         "1.27AB": ab_27_ext,
                         "1.618AB": ab_618_ext,
+                        "2.24BC": c + bc_diff * 2.24,
+                        "2.618BC": c + bc_diff * 2.618,
+                        "3.14BC": c + bc_diff * 3.14,
+                        "3.618BC": c + bc_diff * 3.618,
                     },
                     "1.618XA",
                 )
@@ -3065,7 +3079,7 @@ def find_bearish_crab(
                     {
                         level: (b_idx, price)
                         for level, price in clustered_levels.items()
-                        if price > x
+                        if price > x and price <= xa_618_ext
                     }
                 )
             else:
@@ -3075,6 +3089,8 @@ def find_bearish_crab(
                         "2.618BC": c + bc_diff * 2.618,
                         "3.14BC": c + bc_diff * 3.14,
                         "3.618BC": c + bc_diff * 3.618,
+                        "1.27AB": ab_27_ext,
+                        "1.618AB": ab_618_ext,
                     },
                     "1.618XA",
                 )

--- a/src/utils.py
+++ b/src/utils.py
@@ -2382,17 +2382,9 @@ def find_bullish_gartley(
         b_retrace = fib_ser.loc[(fib_ser - (ab_diff / xa_diff)).abs().idxmin()]
         c_retrace = fib_ser.loc[(fib_ser - (bc_diff / ab_diff)).abs().idxmin()]
 
-        lowest_close_after_c = df.loc[c_idx:, "Close"].min()
-        highest_high_after_c = df.loc[c_idx:, "High"].max()
-
         is_perfect = b_retrace == 0.618 and c_retrace == 0.618
 
-        if (
-            b_retrace != 0.618
-            or c_retrace < 0.382
-            or c_retrace > 0.886
-            or lowest_close_after_c < x
-        ):
+        if b_retrace != 0.618 or c_retrace < 0.382 or c_retrace > 0.886:
             x_idx = pivots.loc[pivots.index[pos_after_x] :, "P"].idxmin()
             x = pivots.loc[x_idx, "P"]
             continue
@@ -2425,10 +2417,9 @@ def find_bullish_gartley(
         if (
             d < b
             and closes_below_terminal_point < 7
-            and c == highest_high_after_c
             and (
                 has_tested
-                and (df.index[-1] - lows_below_terminal_point.index[0]).days < 7
+                and (d_idx - lows_below_terminal_point.index[0]).days < 7
                 or not has_tested
             )
         ):
@@ -2576,17 +2567,9 @@ def find_bearish_gartley(
         b_retrace = fib_ser.loc[(fib_ser - (ab_diff / xa_diff)).abs().idxmin()]
         c_retrace = fib_ser.loc[(fib_ser - (bc_diff / ab_diff)).abs().idxmin()]
 
-        highest_close_after_c = df.loc[c_idx:, "Close"].max()
-        lowest_low_after_c = df.loc[c_idx:, "Low"].min()
-
         is_perfect = b_retrace == 0.618 and c_retrace == 0.618
 
-        if (
-            b_retrace != 0.618
-            or c_retrace < 0.382
-            or c_retrace > 0.886
-            or highest_close_after_c > x
-        ):
+        if b_retrace != 0.618 or c_retrace < 0.382 or c_retrace > 0.886:
             x_idx = pivots.loc[pivots.index[pos_after_x] :, "P"].idxmax()
             x = pivots.loc[x_idx, "P"]
             continue
@@ -2619,10 +2602,9 @@ def find_bearish_gartley(
         if (
             d > b
             and closes_above_terminal_point < 7
-            and c == lowest_low_after_c
             and (
                 has_tested
-                and (df.index[-1] - highs_above_terminal_point.index[0]).days
+                and (d_idx - highs_above_terminal_point.index[0]).days
                 < 7
                 or not has_tested
             )
@@ -2793,9 +2775,8 @@ def find_bullish_crab(
 
         terminal_point = xa_618_ext
 
-        highest_high_after_c = df.loc[c_idx:, "High"].max()
-
         lows_after_c = df.loc[c_idx:, "Low"]
+
         lows_below_terminal_point = lows_after_c.loc[
             lows_after_c < terminal_point
         ]
@@ -2812,10 +2793,9 @@ def find_bullish_crab(
         if (
             d < b - (b - terminal_point) * 0.5
             and closes_below_terminal_point < 7
-            and c == highest_high_after_c
             and (
                 has_tested
-                and (df.index[-1] - lows_below_terminal_point.index[0]).days < 7
+                and (d_idx - lows_below_terminal_point.index[0]).days < 7
                 or not has_tested
             )
         ):
@@ -3007,8 +2987,6 @@ def find_bearish_crab(
 
         terminal_point = xa_618_ext
 
-        lowest_low_after_c = df.loc[c_idx:, "Low"].min()
-
         highs_after_c = df.loc[c_idx:, "High"]
 
         highs_above_terminal_point = highs_after_c[
@@ -3026,16 +3004,13 @@ def find_bearish_crab(
 
         if (
             closes_above_terminal_point < 7
-            and c == lowest_low_after_c
             and d > b + (terminal_point - b) * 0.5
             and (
                 has_tested
-                and (df.index[-1] - highs_above_terminal_point.index[0]).days
-                < 7
+                and (d_idx - highs_above_terminal_point.index[0]).days < 7
                 or not has_tested
             )
         ):
-
             selected = dict(
                 df_start=df.index[0],
                 df_end=df.index[-1],

--- a/src/utils.py
+++ b/src/utils.py
@@ -1576,8 +1576,13 @@ def find_bullish_abcd(
         bc_diff = c - b
         ab_diff = a - b
 
+        lowest_low_ac = df.loc[a_idx:c_idx, "Low"].min()
+        highest_high_from_b = df.loc[b_idx:, "High"].max()
+
         if (
-            a == df.at[a_idx, "Low"]
+            lowest_low_ac != b
+            or highest_high_from_b != c
+            or a == df.at[a_idx, "Low"]
             or b == df.at[b_idx, "High"]
             or c == df.at[c_idx, "Low"]
         ):
@@ -1743,8 +1748,13 @@ def find_bearish_abcd(
         bc_diff = b - c
         ab_diff = b - a
 
+        highest_high_ac = df.loc[a_idx:c_idx, "High"].max()
+        lowest_low_from_b = df.loc[b_idx:, "Low"].min()
+
         if (
-            a == df.at[a_idx, "High"]
+            highest_high_ac != b
+            or lowest_low_from_b != c
+            or a == df.at[a_idx, "High"]
             or b == df.at[b_idx, "Low"]
             or c == df.at[c_idx, "High"]
         ):
@@ -1920,8 +1930,15 @@ def find_bullish_bat(
         ab_diff = a - b
         bc_diff = c - b
 
+        lowest_low_ac = df.loc[a_idx:c_idx, "Low"].min()
+        highest_high_xb = df.loc[x_idx:b_idx, "High"].max()
+        highest_high_from_b = df.loc[b_idx:, "High"].max()
+
         if (
-            x == df.at[x_idx, "High"]
+            highest_high_xb != a
+            or lowest_low_ac != b
+            or highest_high_from_b != c
+            or x == df.at[x_idx, "High"]
             or a == df.at[a_idx, "Low"]
             or b == df.at[b_idx, "High"]
             or c == df.at[c_idx, "Low"]
@@ -2139,8 +2156,15 @@ def find_bearish_bat(
         ab_diff = b - a
         bc_diff = b - c
 
+        lowest_low_from_b = df.loc[b_idx:, "Low"].min()
+        highest_high_ac = df.loc[a_idx:c_idx, "High"].max()
+        lowest_low_xb = df.loc[x_idx:b_idx, "Low"].min()
+
         if (
-            x == df.at[x_idx, "Low"]
+            lowest_low_xb != a
+            or highest_high_ac != b
+            or lowest_low_from_b != c
+            or x == df.at[x_idx, "Low"]
             or a == df.at[a_idx, "High"]
             or b == df.at[b_idx, "Low"]
             or c == df.at[c_idx, "High"]
@@ -2356,8 +2380,17 @@ def find_bullish_gartley(
         ab_diff = a - b
         bc_diff = c - b
 
+        highest_high_xb = df.loc[x_idx:b_idx, "High"].max()
+        lowest_low_ac = df.loc[a_idx:c_idx, "Low"].min()
+        highest_high_from_b = df.loc[b_idx:, "High"].max()
+        lowest_close_from_c = df.loc[c_idx:, "Close"].min()
+
         if (
-            x == df.at[x_idx, "High"]
+            highest_high_xb != a
+            or lowest_low_ac != b
+            or highest_high_from_b != c
+            or lowest_close_from_c < x
+            or x == df.at[x_idx, "High"]
             or a == df.at[a_idx, "Low"]
             or b == df.at[b_idx, "High"]
             or c == df.at[c_idx, "Low"]
@@ -2541,8 +2574,17 @@ def find_bearish_gartley(
         ab_diff = b - a
         bc_diff = b - c
 
+        lowest_low_xb = df.loc[x_idx:b_idx, "Low"].min()
+        highest_high_ac = df.loc[a_idx:c_idx, "High"].max()
+        lowest_low_from_c = df.loc[c_idx:, "Low"].min()
+        highest_close_from_c = df.loc[c_idx:, "Close"].max()
+
         if (
-            x == df.at[x_idx, "Low"]
+            lowest_low_xb != a
+            or highest_high_ac != b
+            or lowest_low_from_c != c
+            or highest_close_from_c > x
+            or x == df.at[x_idx, "Low"]
             or a == df.at[a_idx, "High"]
             or b == df.at[b_idx, "Low"]
             or c == df.at[c_idx, "High"]
@@ -2727,8 +2769,15 @@ def find_bullish_crab(
         ab_diff = a - b
         bc_diff = c - b
 
+        highest_high_xb = df.loc[x_idx:b_idx, "High"].max()
+        lowest_low_ac = df.loc[a_idx:c_idx, "Low"].min()
+        highest_high_from_b = df.loc[b_idx:, "High"].max()
+
         if (
-            x == df.at[x_idx, "High"]
+            highest_high_xb != a
+            or lowest_low_ac != b
+            or highest_high_from_b != c
+            or x == df.at[x_idx, "High"]
             or a == df.at[a_idx, "Low"]
             or b == df.at[b_idx, "High"]
             or c == df.at[c_idx, "Low"]
@@ -2934,8 +2983,15 @@ def find_bearish_crab(
         ab_diff = b - a
         bc_diff = b - c
 
+        lowest_low_xb = df.loc[x_idx:b_idx, "Low"].min()
+        highest_high_ac = df.loc[a_idx:c_idx, "High"].max()
+        lowest_low_from_b = df.loc[b_idx:, "Low"].min()
+
         if (
-            x == df.at[x_idx, "Low"]
+            lowest_low_xb != a
+            or highest_high_ac != b
+            or lowest_low_from_b != c
+            or x == df.at[x_idx, "Low"]
             or a == df.at[a_idx, "High"]
             or b == df.at[b_idx, "Low"]
             or c == df.at[c_idx, "High"]


### PR DESCRIPTION
70ef77d (HEAD -> dev) Bump to version 4.0.7

7a39492 Dont plot chart when `--save` option is used.

1bfa006 Add offset to line labels in expand mode.

cf2548a No offset for the first line label.

    prev_diff is None for the first line. Only add offset when prev_diff is set.

e0bde0a 

- Added additional complementary reversal levels to Crab pattern. 
- Filter out reversal lines outside of X and XA 1.618 extension zone.

713d253 Removed some redundant code from Gartley and Crab pattern.

    These were rearranged and added in an earlier commit. No longer required.

55e262c 

- Use 0.886 XA retracement as terminal point for BAT / Perfect BAT. 
- Use 1.13 XA extension as terminal point for alternate BAT. 
- For Alternate BAT, both regular and alternate reversal zones are plotted. 
- Small changes to variable names, overall code improvements.

58b5359 Set alternate reversal zones if AB=CD is breached on a closing basis.

ffa0272 

- CD leg completion days must not exceed 2x AB leg. 
- Removed a redundant checks.

b75ea48 If AB=CD extension is broken on closing basis, label it as `Alternate AB=CD`

2b87778 Fix: Corrections to some Fib extension and retrace calculations

07b49e3 Added scan option for Butterfly pattern to backtest.py

4ae102a Added scan options for Butterfly pattern to init.py.

63ee244 Added new functions to detect Butterfly harmonic pattern.

f59a772 Added checks to ensure harmonic pattern has correct structure.

677b040 Improve readability of line labels with text rotation and spacing.

    In harmonic patterns, if the reversal lines are too close, the text
    labels overlap and become difficult to read. This adds a 15 degree
    rotation and some spacing in the labels to improve readability.